### PR TITLE
Set the AT_SPI_CLIENT variable in the tests

### DIFF
--- a/src/sugar3/test/unittest.py
+++ b/src/sugar3/test/unittest.py
@@ -35,9 +35,13 @@ class UITestCase(unittest.TestCase):
         self._orig_level = logger.getEffectiveLevel()
         logger.setLevel(logging.DEBUG)
 
+        os.environ["AT_SPI_CLIENT"] = "yes"
+
     def tearDown(self):
         logger = logging.getLogger()
         logger.setLevel(self._orig_level)
+
+        del os.environ["AT_SPI_CLIENT"]
 
     @contextmanager
     def run_view(self, name):


### PR DESCRIPTION
This ensures the test itself is not recognized as a client
by the registry. I'm not sure how that happens since we are
not loading gtk, but it does. Not being a real gtk client with
a mainloop we wasn't answering dbus calls and causing the registry
to hang and fail.
