### PR TITLE
Log the UI tree on error

### DIFF
--- a/src/sugar3/test/unittest.py
+++ b/src/sugar3/test/unittest.py
@@ -51,7 +51,7 @@ class UITestCase(unittest.TestCase):
         try:
             yield
         except:
-            uitree.get_root().dump()
+            logging.debug(uitree.get_root().dump())
             raise
         finally:
             process.terminate()


### PR DESCRIPTION
The dump method doesn't actually print anything, just
returns the tree as a string.
