### PR TITLE
Don't set AT_SPI_CLIENT

### DIFF
--- a/src/sugar3/test/discover.py
+++ b/src/sugar3/test/discover.py
@@ -37,7 +37,6 @@ def main():
 
     os.chdir(args.tests_dir)
     os.environ["TMPDIR"] = temp_dir
-    os.environ["AT_SPI_CLIENT"] = "yes"
 
     try:
         test = unittest.defaultTestLoader.discover(".")


### PR DESCRIPTION
This is not necessary anymore with latest at-spi2-atk
(See commit 683739dea15d7c02c217a404d8c5d9d7af076a57)
