### PR TITLE
Allow override of user library path

### DIFF
--- a/src/sugar3/env.py
+++ b/src/sugar3/env.py
@@ -59,4 +59,5 @@ def get_user_activities_path():
 
 
 def get_user_library_path():
-    return os.path.expanduser('~/Library')
+    return os.environ.get("SUGAR_LIBRARY_PATH",
+                          os.path.expanduser('~/Library'))


### PR DESCRIPTION
This allows for override of ~/Library the same way that can be done
for ~/Activities. Useful for automated testing.
