### PR TITLE
Avoid use of uuid module

### DIFF
--- a/src/sugar3/activity/activityfactory.py
+++ b/src/sugar3/activity/activityfactory.py
@@ -23,7 +23,6 @@ the moment there is no reason to stabilize this API.
 """
 
 import logging
-import uuid
 
 import dbus
 from gi.repository import GObject
@@ -65,7 +64,7 @@ def _close_fds():
 
 def create_activity_id():
     """Generate a new, unique ID for this activity"""
-    return util.unique_id(uuid.getnode())
+    return util.unique_id()
 
 
 def get_environment(activity):


### PR DESCRIPTION
Upon import of uuid, that module uses ctypes.util to find libuuid/libc,
which involves forking a shell process which then forks and runs ldconfig.

ldconfig performs a whole bunch of disk accesses. This is a slowdown.

uuid.getnode() is also documented to be slow. Lets avoid using it in
the activity launch path; we don't need such a high degree of
randomness.

This makes activities launch 1-2 seconds faster on XO-1.
