### PR TITLE
Fix annotation for xdg_mime_list_parents (SL #4530)

### DIFF
--- a/src/sugar3/xdgmime.c
+++ b/src/sugar3/xdgmime.c
@@ -762,7 +762,7 @@ xdg_mime_mime_type_subclass (const char *mime,
 /**
  * sugar_mime_list_mime_parents:
  *
- * Return value: (array zero-terminated=1) (transfer full):
+ * Return value: (transfer container):
  **/
 char **
 xdg_mime_list_mime_parents (const char *mime)
@@ -788,6 +788,11 @@ xdg_mime_list_mime_parents (const char *mime)
   return result;
 }
 
+/**
+ * sugar_mime_get_mime_parents:
+ *
+ * Return value: (transfer none):
+ **/
 const char **
 xdg_mime_get_mime_parents (const char *mime)
 {


### PR DESCRIPTION
As per SL #4530, there is a fatal crash in Sugar when retrieving mimetypes for some Journal entries when contructing the icon palette (for both the Journal list view and detail view). We isolated the problem to xdgmime.c, the call to xdg_get_mime_parents. Dnarvaez observed that the annotation for the return argument was missing and that the annotation for the return for mime_list_parents was wrong. This patch fixes these annotations.
