### PR TITLE
Include string.h to sugar-fatattr

### DIFF
--- a/src/sugar3/sugar-fatattr.c
+++ b/src/sugar3/sugar-fatattr.c
@@ -30,6 +30,7 @@
 
 #include <errno.h>
 #include <stdio.h>
+#include <string.h>
 
 // This function is wrapped by getattrs/setattrs
 static int _ioctl_attrs(char *file, __u32 *attrs, int ioctlnum, char *verb)


### PR DESCRIPTION
According to dsd's wisdom, without being
included, strerror is undeclared.

Fixes #4600 sugar crashing when copying
journal entries to documents folder.

Signed-off-by: Martin Abente Lahaye tch@sugarlabs.org
