### PR TITLE
Drop use of deprecated dbus.glib

### DIFF
--- a/bin/sugar-activity
+++ b/bin/sugar-activity
@@ -29,7 +29,8 @@ from optparse import OptionParser
 
 import dbus
 import dbus.service
-import dbus.glib
+from dbus.mainloop.glib import DBusGMainLoop
+DBusGMainLoop(set_as_default=True)
 
 from sugar3.activity import activityhandle
 from sugar3.activity import i18n

--- a/src/sugar3/datastore/datastore.py
+++ b/src/sugar3/datastore/datastore.py
@@ -29,7 +29,6 @@ from gi.repository import GObject
 from gi.repository import GConf
 from gi.repository import Gio
 import dbus
-import dbus.glib
 
 from sugar3 import env
 from sugar3 import mime

--- a/src/sugar3/presence/presenceservice.py
+++ b/src/sugar3/presence/presenceservice.py
@@ -25,7 +25,6 @@ import logging
 from gi.repository import GObject
 import dbus
 import dbus.exceptions
-import dbus.glib
 from dbus import PROPERTIES_IFACE
 
 from sugar3.presence.buddy import Buddy, Owner


### PR DESCRIPTION
When writing Python apps that will use asynchronous DBus calls and
signals, python-dbus must be initialised with the appropriate main
loop.

sugar currently does this by importing the datastore module from
sugar-toolkit-gtk3, and the datastore module uses the deprecated
and confusing dbus.glib module (which automatically and non-obviously
sets the default GLib main context as the DBus mainloop).

Eliminate the dbus.glib usage from sugar-toolkit-gtk3 as part
of the effort to make sugar initialised the DBus mainloop in a
more explicit and non-deprecated fashion.
