### PR TITLE
Ensure entity value is type str

### DIFF
--- a/src/sugar3/graphics/icon.py
+++ b/src/sugar3/graphics/icon.py
@@ -55,6 +55,8 @@ class _SVGLoader(object):
                 self._cache[file_name] = icon
 
         for entity, value in entities.items():
+            if isinstance(value, unicode):
+                value = value.encode('ascii', 'replace')
             if isinstance(value, basestring):
                 xml = '<!ENTITY %s "%s">' % (entity, value)
                 icon = re.sub('<!ENTITY %s .*>' % entity, xml, icon)


### PR DESCRIPTION
As per SL #4621, there are times when the entity value passed in for
substitution is of type unicode. This causes Rsvg to fail when
processing the SVG. This patch checks for unicode and converts it to
ascii.
