### PR TITLE
Ensure entity value is type str - SL #4621

### DIFF
--- a/src/sugar3/graphics/icon.py
+++ b/src/sugar3/graphics/icon.py
@@ -113,9 +113,9 @@ class _IconBuffer(object):
     def _load_svg(self, file_name):
         entities = {}
         if self.fill_color:
-            entities['fill_color'] = self.fill_color
+            entities['fill_color'] = self.fill_color.encode('utf-8')
         if self.stroke_color:
-            entities['stroke_color'] = self.stroke_color
+            entities['stroke_color'] = self.stroke_color.encode('utf-8')
 
         return self._loader.load(file_name, entities, self.cache)
 


### PR DESCRIPTION
As per SL #4621, there are times when the entity value passed in for
substitution is of type unicode. This causes Rsvg to fail when
processing the SVG. This patch checks for unicode and converts it to
utf-8.
