### PR TITLE
Ensure entity value is type str - SL #4621

### DIFF
--- a/src/sugar3/graphics/icon.py
+++ b/src/sugar3/graphics/icon.py
@@ -62,7 +62,7 @@ class _SVGLoader(object):
                 logging.error(
                     'Icon %s, entity %s is invalid.', file_name, entity)
 
-        return Rsvg.Handle.new_from_data(icon)
+        return Rsvg.Handle.new_from_data(icon.encode('utf-8'))
 
 
 class _IconInfo(object):


### PR DESCRIPTION
As per SL #4621, there are times when the entity value passed in for
substitution is of type unicode. This causes Rsvg to fail when
processing the SVG. This patch checks for unicode and converts it to
utf-8.

As per the discussion on PRs 34 and 35, moving the encoding to the SVG loader.
