### PR TITLE
Use python2 shebang

### DIFF
--- a/bin/sugar-activity
+++ b/bin/sugar-activity
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2006-2008, Red Hat, Inc.
 #

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,7 @@ GNOME_COMPILE_WARNINGS(maximum)
 
 AC_PATH_PROG([GLIB_GENMARSHAL], [glib-genmarshal])
 
+PYTHON=python2
 AM_PATH_PYTHON
 AM_CHECK_PYTHON_HEADERS(,[AC_MSG_ERROR(could not find Python headers)])
 

--- a/tests/data/sample.activity/setup.py
+++ b/tests/data/sample.activity/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from sugar3.activity import bundlebuilder
 

--- a/tests/test_mime.py
+++ b/tests/test_mime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2006, Red Hat, Inc.
 # Copyright (C) 2007, One Laptop Per Child


### PR DESCRIPTION
Some distributions have switched to python3 as default and our code
breaks because it's python2 specific. Follow the PEP 394
recommendation.
