### PR TITLE
Add one_open_instance field to activity bundle

### DIFF
--- a/src/sugar3/bundle/activitybundle.py
+++ b/src/sugar3/bundle/activitybundle.py
@@ -108,6 +108,7 @@ class ActivityBundle(Bundle):
         self._tags = None
         self._activity_version = '0'
         self._summary = None
+        self._one_open_instance = False
 
         info_file = self.get_file('activity/activity.info')
         if info_file is None:
@@ -172,6 +173,11 @@ class ActivityBundle(Bundle):
 
         if cp.has_option(section, 'summary'):
             self._summary = cp.get(section, 'summary')
+
+        if cp.has_option(section, 'one_open_instance'):
+            logging.error(cp.get(section, 'one_open_instance'))
+            if cp.get(section, 'one_open_instance') == 'yes':
+                self._one_open_instance = True
 
     def _get_linfo_file(self):
         # Using method from gettext.py, first find languages from environ
@@ -272,6 +278,10 @@ class ActivityBundle(Bundle):
     def get_summary(self):
         """Get the summary that describe the activity"""
         return self._summary
+
+    def get_one_open_instance(self):
+        """Get whether there should only be one instance for the activity"""
+        return self._one_open_instance
 
     def get_show_launcher(self):
         """Get whether there should be a visible launcher for the activity"""


### PR DESCRIPTION
This field can be used by activities that need to be restricted to one
open instance. Usage is:

one_open_instance = true

jarabe/model/shell.py has been modified look for this field in a
separate patch to Sugar.

Together these two patches constitute the implementation of Sugar
feature Launch Limits [1]

[1] http://wiki.sugarlabs.org/go/Features/Launch_Limits
