### PR TITLE
Make gir files depend on their library

### DIFF
--- a/src/sugar3/Makefile.am
+++ b/src/sugar3/Makefile.am
@@ -142,6 +142,7 @@ SugarExt_1_0_gir_FILES = \
     sugar-gconf.h \
 	$(XDG_MIME_SOURCES)
 
+SugarExt_1_0_gir: libsugarext.la
 SugarExt_1_0_gir_INCLUDES = Gtk-3.0 Gdk-3.0 GConf-2.0
 SugarExt_1_0_gir_PACKAGES = gtk+-3.0 gdk-3.0 gconf-2.0
 SugarExt_1_0_gir_EXPORT_PACKAGES = SugarExt-1.0

--- a/src/sugar3/event-controller/Makefile.am
+++ b/src/sugar3/event-controller/Makefile.am
@@ -58,6 +58,7 @@ SugarGestures_1_0_gir_FILES =	\
 SugarGestures_1_0_gir_CFLAGS =	\
 	-DSUGAR_TOOLKIT_COMPILATION --warn-all
 
+SugarGestures-1.0.gir: libsugar-eventcontroller.la
 SugarGestures_1_0_gir_INCLUDES = Gtk-3.0 Gdk-3.0
 SugarGestures_1_0_gir_PACKAGES = gtk+-3.0 gdk-3.0
 SugarGestures_1_0_gir_EXPORT_PACKAGES = SugarGestures-1.0


### PR DESCRIPTION
Otherwise with parallel builds we might try to build gir files
before the library causing an error. This happened once in the
buildbot.

Fix #4606
