### PR TITLE
Add single_instance field to activity bundle

### DIFF
--- a/src/sugar3/bundle/activitybundle.py
+++ b/src/sugar3/bundle/activitybundle.py
@@ -108,6 +108,7 @@ class ActivityBundle(Bundle):
         self._tags = None
         self._activity_version = '0'
         self._summary = None
+        self._single_instance = False
 
         info_file = self.get_file('activity/activity.info')
         if info_file is None:
@@ -128,9 +129,15 @@ class ActivityBundle(Bundle):
         if cp.has_option(section, 'bundle_id'):
             self._bundle_id = cp.get(section, 'bundle_id')
         else:
-            raise MalformedBundleException(
-                'Activity bundle %s does not specify a bundle id' %
-                self._path)
+            if cp.has_option(section, 'service_name'):
+                self._bundle_id = cp.get(section, 'service_name')
+                logging.error('ATTENTION: service_name property in the '
+                              'activity.info file is deprecated, should be '
+                              ' changed to bundle_id')
+            else:
+                raise MalformedBundleException(
+                    'Activity bundle %s does not specify a bundle id' %
+                    self._path)
 
         if cp.has_option(section, 'name'):
             self._name = cp.get(section, 'name')
@@ -172,6 +179,11 @@ class ActivityBundle(Bundle):
 
         if cp.has_option(section, 'summary'):
             self._summary = cp.get(section, 'summary')
+
+        if cp.has_option(section, 'single_instance'):
+            logging.error(cp.get(section, 'single_instance'))
+            if cp.get(section, 'single_instance') == 'yes':
+                self._single_instance = True
 
     def _get_linfo_file(self):
         # Using method from gettext.py, first find languages from environ
@@ -272,6 +284,10 @@ class ActivityBundle(Bundle):
     def get_summary(self):
         """Get the summary that describe the activity"""
         return self._summary
+
+    def get_single_instance(self):
+        """Get whether there should be a single instance for the activity"""
+        return self._single_instance
 
     def get_show_launcher(self):
         """Get whether there should be a visible launcher for the activity"""


### PR DESCRIPTION
This field can be used by activities that need to be restricted to a
single open instance. Usage is:

single_instance = yes

jarabe/model/shell.py has been modified look for this field in a
separate patch to Sugar.

Together these two patches constitute the implementation of Sugar
feature Launch Limits [1]

[1] http://wiki.sugarlabs.org/go/Features/Launch_Limits
