### PR TITLE
Make webactivity compatible with webkit1

### DIFF
--- a/src/sugar3/activity/webactivity.py
+++ b/src/sugar3/activity/webactivity.py
@@ -17,16 +17,90 @@
 
 import json
 import os
+import logging
+
+USE_WEBKIT1 = 'SUGAR_USE_WEBKIT1' in os.environ
 
 from gi.repository import Gdk
 from gi.repository import Gio
-from gi.repository import WebKit2
 from gi.repository import Gtk
 from gi.repository import GdkX11
 assert GdkX11
 
+if USE_WEBKIT1:
+    from gi.repository import GObject
+    GObject.threads_init()
+    from gi.repository import WebKit
+    import socket
+    from threading import Thread
+    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+    import SocketServer
+    import select
+    import errno
+    import mimetypes
+else:
+    from gi.repository import WebKit2
+
 from gi.repository import SugarExt
 from sugar3.activity import activity
+
+
+if USE_WEBKIT1:
+
+    class LocalRequestHandler(BaseHTTPRequestHandler):
+
+        #Handler for the GET requests
+        def do_GET(self):
+            new_path = self.server.path + '/' + self.path
+            if not os.path.exists(new_path):
+                logging.error('file %s not found.', new_path)
+                return False
+
+            with open(new_path) as f:
+                content = f.read()
+            self.send_response(200)
+            mime, _encoding = mimetypes.guess_type(self.path)
+            self.send_header("Content-type", mime)
+            self.end_headers()
+            self.wfile.write(content)
+            return False
+
+    class LocalHTTPServer(HTTPServer):
+
+        def __init__(self, server_address, request_handler, path):
+            self.path = path
+            HTTPServer.__init__(self, server_address, request_handler)
+
+        def serve_forever(self, poll_interval=0.5):
+            """Overridden version of BaseServer.serve_forever that
+            does not fail to work when EINTR is received.
+            """
+            self._BaseServer__serving = True
+            self._BaseServer__is_shut_down.clear()
+            while self._BaseServer__serving:
+
+                # XXX: Consider using another file descriptor or
+                # connecting to the socket to wake this up instead of
+                # polling. Polling reduces our responsiveness to a
+                # shutdown request and wastes cpu at all other times.
+                try:
+                    r, w, e = select.select([self], [], [], poll_interval)
+                except select.error, e:
+                    if e[0] == errno.EINTR:
+                        logging.debug("got eintr")
+                        continue
+                    raise
+                if r:
+                    self._handle_request_noblock()
+            self._BaseServer__is_shut_down.set()
+
+        def server_bind(self):
+            """Override server_bind in HTTPServer to not use
+            getfqdn to get the server name because is very slow."""
+            SocketServer.TCPServer.server_bind(self)
+            _host, port = self.socket.getsockname()[:2]
+            self.server_name = 'localhost'
+            self.server_port = port
 
 
 class WebActivity(Gtk.Window):
@@ -42,21 +116,46 @@ class WebActivity(Gtk.Window):
         self.set_decorated(False)
         self.maximize()
 
-        self.connect("key-press-event", self._key_press_event_cb)
         self.connect('realize', self._realize_cb)
         self.connect('destroy', self._destroy_cb)
 
-        context = WebKit2.WebContext.get_default()
-        context.register_uri_scheme("activity", self._app_scheme_cb, None)
+        if USE_WEBKIT1:
+            # Get a free socket
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind(('', 0))
+            sock.listen(socket.SOMAXCONN)
+            _ipaddr, self.port = sock.getsockname()
+            sock.shutdown(socket.SHUT_RDWR)
+            logging.error('Using port %d', self.port)
 
-        self._web_view = WebKit2.WebView()
-        self._web_view.connect("load-changed", self._loading_changed_cb)
+            # start the local web server
+            httpd = LocalHTTPServer(('', self.port),
+                                    lambda *args: LocalRequestHandler(*args),
+                                    activity.get_bundle_path())
+            self._server = Thread(target=httpd.serve_forever)
+            self._server.setDaemon(True)
+            self._server.start()
+
+            self._web_view = WebKit.WebView()
+            self._web_view.connect("notify::load-status",
+                                   self._loading_changed_cb)
+            self._web_view.connect("resource-request-starting",
+                                   self._resource_request_starting_cb)
+        else:
+            context = WebKit2.WebContext.get_default()
+            context.register_uri_scheme("activity", self._app_scheme_cb, None)
+
+            self._web_view = WebKit2.WebView()
+            self._web_view.connect("load-changed", self._loading_changed_cb)
+
+            settings = self._web_view.get_settings()
+            settings.set_property("enable-developer-extras", True)
+
+            self.connect("key-press-event", self._key_press_event_cb)
 
         self.add(self._web_view)
         self._web_view.show()
-
-        settings = self._web_view.get_settings()
-        settings.set_property("enable-developer-extras", True)
 
         self._web_view.load_uri("activity://%s/index.html" % self._bundle_id)
 
@@ -74,8 +173,27 @@ class WebActivity(Gtk.Window):
         self.destroy()
         Gtk.main_quit()
 
+    def _resource_request_starting_cb(self, webview, web_frame, web_resource,
+                                      request, response):
+        # this is used only in the case of webkit1
+        uri = web_resource.get_uri()
+        if uri.startswith('activity://'):
+            prefix = "activity://%s" % self._bundle_id
+            new_prefix = "http://0.0.0.0:%d" % self.port
+            new_uri = new_prefix + uri[len(prefix):]
+
+            request.set_uri(new_uri)
+
     def _loading_changed_cb(self, web_view, load_event):
-        if load_event == WebKit2.LoadEvent.FINISHED:
+
+        finished = False
+        if USE_WEBKIT1:
+            status = web_view.get_load_status()
+            finished = (status == WebKit.LoadStatus.FINISHED)
+        else:
+            finished = (load_event == WebKit2.LoadEvent.FINISHED)
+
+        if finished:
             key = os.environ["SUGAR_APISOCKET_KEY"]
             port = os.environ["SUGAR_APISOCKET_PORT"]
 
@@ -99,7 +217,10 @@ class WebActivity(Gtk.Window):
                          window.sugar.onEnvironmentSet();
                     """ % env_json
 
-            self._web_view.run_javascript(script, None, None, None)
+            if USE_WEBKIT1:
+                self._web_view.execute_script(script)
+            else:
+                self._web_view.run_javascript(script, None, None, None)
 
     def _key_press_event_cb(self, window, event):
         key_name = Gdk.keyval_name(event.keyval)


### PR DESCRIPTION
If a env variable SUGAR_USE_WEBKIT1 exists,
uses a local webserver, borrowed from wikipedia activity.
Other compatibility changes are needed, like variables and methods
names.
When use webkit1 the web inspector is not enabled, because do not work.

Signed-off-by: Manuel Quiñones manuq@laptop.org
Signed-off-by: Gonzalo Odiard gonzalo@laptop.org
