### PR TITLE
Fix cloning activity in sugar - SL #4608

### DIFF
--- a/src/sugar3/activity/bundlebuilder.py
+++ b/src/sugar3/activity/bundlebuilder.py
@@ -64,10 +64,11 @@ def list_files(base_dir, ignore_dirs=None, ignore_files=None):
 
 class Config(object):
 
-    def __init__(self, source_dir):
+    def __init__(self, source_dir, dist_dir=None, dist_name=None):
         self.source_dir = source_dir
         self.build_dir = os.getcwd()
-        self.dist_dir = os.path.join(self.build_dir, 'dist')
+        self.dist_dir = dist_dir or os.path.join(self.source_dir, 'dist')
+        self.dist_name = dist_name
         self.bundle = None
         self.version = None
         self.activity_name = None
@@ -91,8 +92,11 @@ class Config(object):
         self.bundle_name = reduce(operator.add, self.activity_name.split())
         self.bundle_root_dir = self.bundle_name + '.activity'
         self.tar_root_dir = '%s-%s' % (self.bundle_name, self.version)
-        self.xo_name = '%s-%s.xo' % (self.bundle_name, self.version)
-        self.tar_name = '%s-%s.tar.bz2' % (self.bundle_name, self.version)
+        if self.dist_name:
+            self.xo_name = self.tar_name = self.dist_name
+        else:
+            self.xo_name = '%s-%s.xo' % (self.bundle_name, self.version)
+            self.tar_name = '%s-%s.tar.bz2' % (self.bundle_name, self.version)
 
 
 class Builder(object):


### PR DESCRIPTION
Probably this code was not included in the initial port from gtk2 to
gtk3, because is only used by Sugar, but now we need it.

As a reference, the code is similar in sugar-toolkit:
https://git.sugarlabs.org/sugar-toolkit/mainline/blobs/master/src/sugar/activity/bundlebuilder.py#line67

Fixes #4608

Signed-off-by: Gonzalo Odiard gonzalo@laptop.org
