### PR TITLE
Fixes #4634 , issue where spaces in bundle ids crashed sugar

### DIFF
--- a/src/sugar3/bundle/activitybundle.py
+++ b/src/sugar3/bundle/activitybundle.py
@@ -128,12 +128,16 @@ class ActivityBundle(Bundle):
 
         if cp.has_option(section, 'bundle_id'):
             self._bundle_id = cp.get(section, 'bundle_id')
+            if ' ' in self._bundle_id:
+                raise MalformedBundleException('Space in bundle_id')
         else:
             if cp.has_option(section, 'service_name'):
                 self._bundle_id = cp.get(section, 'service_name')
                 logging.error('ATTENTION: service_name property in the '
                               'activity.info file is deprecated, should be '
                               ' changed to bundle_id')
+                if ' ' in self._bundle_id:
+                    raise MalformedBundleException('Space in bundle_id')
             else:
                 raise MalformedBundleException(
                     'Activity bundle %s does not specify a bundle id' %


### PR DESCRIPTION
This patch also makes a very loud noise in sugar build and stops the build, alerting devs to their error.
