### PR TITLE
Add get_show_launcher() in bundles other than activitybundle

### DIFF
--- a/src/sugar3/bundle/bundle.py
+++ b/src/sugar3/bundle/bundle.py
@@ -161,6 +161,9 @@ class Bundle(object):
         installed."""
         return self._installation_time
 
+    def get_show_launcher(self):
+        return True
+
     def _unzip(self, install_dir):
         if self._zip_file is None:
             raise AlreadyInstalledException


### PR DESCRIPTION
This is needed now by Sugar, after (sugar commit)
f4638b5f481478e96195d55aa38c90fd33db9aee

Signed-off-by: Gonzalo Odiard gonzalo@laptop.org
