### PR TITLE
Touch UI: esc fullscreen

### DIFF
--- a/src/sugar3/graphics/window.py
+++ b/src/sugar3/graphics/window.py
@@ -92,7 +92,7 @@ class Window(Gtk.Window):
         self.set_decorated(False)
         self.maximize()
         self.connect('realize', self.__window_realize_cb)
-        self.connect('key-press-event', self.__key_press_cb)
+        self.connect_after('key-press-event', self.__key_press_cb)
 
         # OSK support: canvas auto panning based on input focus
         if GObject.signal_lookup('request-clear-area', Window) != 0 and \


### PR DESCRIPTION
Fixes #475

This patch adds the possibily for activities to choose whether pressing the Esc key will exit fullscreen mode.
