### PR TITLE
Fixes #3287, Better journal icons

### DIFF
--- a/src/sugar3/mime.py
+++ b/src/sugar3/mime.py
@@ -88,7 +88,7 @@ _generic_types = [{
 }, {
     'id': GENERIC_TYPE_BUNDLE,
     'name': _('Bundle'),
-    'icon': 'user-documents',
+    'icon': 'xo-bundle',
     'types': ['application/vnd.olpc-sugar'],
 }]
 


### PR DESCRIPTION
This split the bundle icon from the docs icon so I could edit it in my pr on sugar-artwork
