### PR TITLE
Fixes #3287, better journal icons

### DIFF
--- a/src/sugar3/graphics/combobox.py
+++ b/src/sugar3/graphics/combobox.py
@@ -21,7 +21,12 @@ STABLE.
 
 from gi.repository import GObject
 from gi.repository import Gtk
+from gi.repository import Gdk
 from gi.repository import GdkPixbuf
+import logging
+
+from sugar3.graphics.icon import get_icon_as_pixbuf
+from sugar3.graphics.xocolor import XoColor
 
 
 class ComboBox(Gtk.ComboBox):
@@ -61,7 +66,8 @@ class ComboBox(Gtk.ComboBox):
         del info
         return fname
 
-    def append_item(self, action_id, text, icon_name=None, file_name=None):
+    def append_item(self, action_id, text, icon_name=None, file_name=None,
+                    high_contrast=False):
         if not self._icon_renderer and (icon_name or file_name):
             self._icon_renderer = Gtk.CellRendererPixbuf()
 
@@ -88,8 +94,20 @@ class ComboBox(Gtk.ComboBox):
             if icon_name:
                 file_name = self._get_real_name_from_theme(icon_name, size)
 
-            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(
-                file_name, width, height)
+            if high_contrast:
+                svg = get_icon_as_pixbuf(file_name, XoColor('#ffffff,#000000'))
+                #This pixbuf is 55 by 55, and we need 22 by 22 for the menu
+                #Otherwise it looks cool but totaly out of place :O
+                if svg is None:
+                    pixbuf = None
+                else:
+                    svg.scale(svg, 0, 0, 55, 55,
+                                  0, 0, 0.4, 0.4,
+                                  GdkPixbuf.InterpType.BILINEAR)
+                    pixbuf = svg.new_subpixbuf(0, 0, 22, 22)
+            else:
+                pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(
+                    file_name, width, height)
         else:
             pixbuf = None
 

--- a/src/sugar3/graphics/icon.py
+++ b/src/sugar3/graphics/icon.py
@@ -330,6 +330,21 @@ class _IconBuffer(object):
 
     xo_color = property(_get_xo_color, _set_xo_color)
 
+def get_icon_as_pixbuf(file_name, xocolor):
+    """
+    This returns any svg icon as a GdkPixbuf.Pixbuf
+    The icon will be 55px by 55px
+    """
+    buffer_ = _IconBuffer()
+    #b.icon_size = size
+    buffer_.file_name = file_name
+    buffer_.stroke_color = xocolor.get_stroke_color()
+    buffer_.fill_color = xocolor.get_fill_color()
+    svg = buffer_.get_surface()
+    if svg is None:
+        return None
+    else:
+        return Gdk.pixbuf_get_from_surface(svg, 0, 0, 55, 55)
 
 class Icon(Gtk.Image):
 


### PR DESCRIPTION
Make the icons look black and white and all things nice :laughing:. Best of all you can use this all throughout :lollipop: sugar!
To see it in action you need these: https://github.com/sugarlabs/sugar/pull/192
