### PR TITLE
Remove Gtk.IconSize from toolkit.

### DIFF
--- a/examples/iconcache.py
+++ b/examples/iconcache.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2007, Red Hat, Inc.
+# Copyright (C) 2014, Ignacio Rodriguez
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -21,6 +22,7 @@ Test the sugar3.graphics.icon.* cache.
 
 from gi.repository import Gtk
 
+from sugar3.graphics import style
 from sugar3.graphics.icon import Icon
 from sugar3.graphics.xocolor import XoColor
 
@@ -54,7 +56,7 @@ def _button_activated_cb(button):
 
 for d in data:
     icon = Icon(icon_name=d[0],
-                icon_size=Gtk.IconSize.LARGE_TOOLBAR,
+                pixel_size=style.STANDARD_ICON_SIZE,
                 xo_color=XoColor(d[1]))
     test.pack_start(icon, True, True, 0)
     icon.show()

--- a/examples/iconwidget.py
+++ b/examples/iconwidget.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2007, Red Hat, Inc.
+# Copyright (C) 2014, Ignacio Rodriguez
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -21,6 +22,7 @@ Test the sugar3.graphics.icon.Icon widget.
 
 from gi.repository import Gtk
 
+from sugar3.graphics import style
 from sugar3.graphics.icon import Icon
 from sugar3.graphics.xocolor import XoColor
 
@@ -40,27 +42,27 @@ hbox.show_all()
 
 def create_icon_widgets(box, sensitive=True):
     icon = Icon(icon_name='go-previous')
-    icon.props.icon_size = Gtk.IconSize.LARGE_TOOLBAR
+    icon.props.pixel_size = style.STANDARD_ICON_SIZE
     box.pack_start(icon, True, True, 0)
     icon.set_sensitive(sensitive)
     icon.show()
 
     icon = Icon(icon_name='computer-xo',
-                icon_size=Gtk.IconSize.LARGE_TOOLBAR,
+                pixel_size=style.STANDARD_ICON_SIZE,
                 xo_color=XoColor())
     box.pack_start(icon, True, True, 0)
     icon.set_sensitive(sensitive)
     icon.show()
 
     icon = Icon(icon_name='battery-000',
-                icon_size=Gtk.IconSize.LARGE_TOOLBAR,
+                pixel_size=style.STANDARD_ICON_SIZE,
                 badge_name='emblem-busy')
     box.pack_start(icon, True, True, 0)
     icon.set_sensitive(sensitive)
     icon.show()
 
     icon = Icon(icon_name='gtk-new',
-                icon_size=Gtk.IconSize.LARGE_TOOLBAR,
+                pixel_size=style.STANDARD_ICON_SIZE,
                 badge_name='gtk-cancel')
     box.pack_start(icon, True, True, 0)
     icon.set_sensitive(sensitive)

--- a/examples/ticket2855.py
+++ b/examples/ticket2855.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2007, Red Hat, Inc.
+# Copyright (C) 2014, Ignacio Rodriguez
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -23,6 +24,7 @@ controls. Ticket #2855.
 
 from gi.repository import Gtk
 
+from sugar3.graphics import style
 from sugar3.graphics.palette import Palette
 from sugar3.graphics.icon import Icon
 
@@ -37,7 +39,7 @@ box = Gtk.HBox()
 
 toggle = Gtk.ToggleButton()
 
-icon = Icon(icon_name='go-previous', icon_size=Gtk.IconSize.LARGE_TOOLBAR)
+icon = Icon(icon_name='go-previous', pixel_size=style.STANDARD_ICON_SIZE)
 toggle.set_image(icon)
 
 box.pack_start(toggle, False)
@@ -45,7 +47,7 @@ toggle.show()
 
 radio = Gtk.RadioButton()
 
-icon = Icon(icon_name='go-next', icon_size=Gtk.IconSize.LARGE_TOOLBAR)
+icon = Icon(icon_name='go-next', pixel_size=style.STANDARD_ICON_SIZE)
 radio.set_image(icon)
 
 radio.set_mode(False)

--- a/src/sugar3/graphics/alert.py
+++ b/src/sugar3/graphics/alert.py
@@ -29,6 +29,7 @@ STABLE.
 """
 # Copyright (C) 2007, One Laptop Per Child
 # Copyright (C) 2010, Anish Mangal <anishmangal2002@gmail.com>
+# Copyright (C) 2014, Ignacio Rodriguez <ignacio@sugarlabs.org>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -355,11 +356,11 @@ class _TimeoutIcon(Gtk.Alignment):
         return False
 
     def do_get_preferred_width(self):
-        width = Gtk.icon_size_lookup(Gtk.IconSize.BUTTON)[1]
+        width = Gtk.icon_size_lookup(style.SMALL_ICON_SIZE)[1]
         return width, width
 
     def do_get_preferred_height(self):
-        height = Gtk.icon_size_lookup(Gtk.IconSize.BUTTON)[2]
+        height = Gtk.icon_size_lookup(style.SMALL_ICON_SIZE)[2]
         return height, height
 
     def _draw(self, context):

--- a/src/sugar3/graphics/colorbutton.py
+++ b/src/sugar3/graphics/colorbutton.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2007, Red Hat, Inc.
 # Copyright (C) 2008, Benjamin Berg <benjamin@sipsolutions.net>
+# Copyright (C) 2014, Ignacio Rodriguez
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -59,7 +60,7 @@ class _ColorButton(Gtk.Button):
         self._accept_drag = True
 
         self._preview = Icon(icon_name='color-preview',
-                             icon_size=Gtk.IconSize.BUTTON)
+                             pixel_size=style.SMALL_ICON_SIZE)
 
         GObject.GObject.__init__(self, **kwargs)
 
@@ -331,7 +332,7 @@ class _ColorPalette(Palette):
             button = _ColorButton(has_palette=False,
                                   color=Gdk.color_parse(color),
                                   accept_drag=False,
-                                  icon_size=Gtk.IconSize.LARGE_TOOLBAR)
+                                  pixel_size=style.STANDARD_ICON_SIZE)
             button.set_relief(Gtk.ReliefStyle.NONE)
             self._swatch_tray.attach(button,
                                      i % rows, i % rows + 1,
@@ -448,7 +449,7 @@ class ColorToolButton(Gtk.ToolItem):
 
         # The following is so that the behaviour on the toolbar is correct.
         color_button.set_relief(Gtk.ReliefStyle.NONE)
-        color_button.icon_size = Gtk.IconSize.LARGE_TOOLBAR
+        color_button.icon_size = style.STANDARD_ICON_SIZE
 
         self._palette_invoker.attach_tool(self)
         self._palette_invoker.props.toggle_palette = True

--- a/src/sugar3/graphics/icon.py
+++ b/src/sugar3/graphics/icon.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2006-2007 Red Hat, Inc.
+# Copyright (C) 2014 Ignacio Rodriguez
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -998,7 +999,8 @@ def get_icon_state(base_name, perc, step=5):
 
 def get_icon_file_name(icon_name):
     icon_theme = Gtk.IconTheme.get_default()
-    info = icon_theme.lookup_icon(icon_name, Gtk.IconSize.LARGE_TOOLBAR, 0)
+    from sugar3.graphics import style
+    info = icon_theme.lookup_icon(icon_name, style.STANDARD_ICON_SIZE, 0)
     if not info:
         return None
     filename = info.get_filename()

--- a/src/sugar3/graphics/iconentry.py
+++ b/src/sugar3/graphics/iconentry.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2007, One Laptop Per Child
+# Copyright (C) 2014, Ignacio Rodriguez
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -42,7 +43,7 @@ class IconEntry(Gtk.Entry):
     def set_icon_from_name(self, position, name):
         icon_theme = Gtk.IconTheme.get_default()
         icon_info = icon_theme.lookup_icon(name,
-                                           Gtk.IconSize.SMALL_TOOLBAR,
+                                           style.SMALL_ICON_SIZE,
                                            0)
         if not icon_info:
             logging.warning('IconEntry set_icon_from_name: icon \'%s\' not '

--- a/src/sugar3/graphics/menuitem.py
+++ b/src/sugar3/graphics/menuitem.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2007, Eduardo Silva <edsiper@gmail.com>
+# Copyright (C) 2014, Ignacio Rodriguez <ignacio@sugarlabs.org>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -48,14 +49,14 @@ class MenuItem(Gtk.ImageMenuItem):
 
         if icon_name is not None:
             icon = Icon(icon_name=icon_name,
-                        icon_size=Gtk.IconSize.SMALL_TOOLBAR)
+                        pixel_size=style.SMALL_ICON_SIZE)
             if xo_color is not None:
                 icon.props.xo_color = xo_color
             self.set_image(icon)
             icon.show()
 
         elif file_name is not None:
-            icon = Icon(file=file_name, icon_size=Gtk.IconSize.SMALL_TOOLBAR)
+            icon = Icon(file=file_name, pixel_size=style.SMALL_ICON_SIZE)
             if xo_color is not None:
                 icon.props.xo_color = xo_color
             self.set_image(icon)

--- a/src/sugar3/graphics/notebook.py
+++ b/src/sugar3/graphics/notebook.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2007, Eduardo Silva (edsiper@gmail.com)
+# Copyright (C) 2014, Ignacio Rodriguez <ignacio@sugarlabs.org>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -26,6 +27,8 @@ STABLE.
 
 from gi.repository import Gtk
 from gi.repository import GObject
+
+from sugar3.graphics import style
 
 
 class Notebook(Gtk.Notebook):
@@ -77,12 +80,12 @@ class Notebook(Gtk.Notebook):
     def _add_icon_to_button(self, button):
         icon_box = Gtk.HBox()
         image = Gtk.Image()
-        image.set_from_stock(Gtk.STOCK_CLOSE, Gtk.IconSize.MENU)
+        image.set_from_stock(Gtk.STOCK_CLOSE, style.SMALL_ICON_SIZE)
         Gtk.Button.set_relief(button, Gtk.ReliefStyle.NONE)
 
         settings = Gtk.Widget.get_settings(button)
         valid_, w, h = Gtk.icon_size_lookup_for_settings(settings,
-                                                         Gtk.IconSize.MENU)
+                                                         style.SMALL_ICON_SIZE)
         Gtk.Widget.set_size_request(button, w + 4, h + 4)
         image.show()
         icon_box.pack_start(image, True, False, 0)

--- a/src/sugar3/graphics/palette.py
+++ b/src/sugar3/graphics/palette.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2009, Tomeu Vizoso
 # Copyright (C) 2011, Benjamin Berg <benjamin@sipsolutions.net>
 # Copyright (C) 2011, Marco Pesenti Gritti <marco@marcopg.org>
+# Copyright (C) 2014, Ignacio Rodriguez <ignacio@sugarlabs.org>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -306,7 +307,7 @@ class Palette(PaletteWindow):
             event_box.show()
 
             self._icon = icon
-            self._icon.props.icon_size = Gtk.IconSize.LARGE_TOOLBAR
+            self._icon.props.pixel_size = style.STANDARD_ICON_SIZE
             event_box.add(self._icon)
             self._icon.show()
             self._show_icon()

--- a/src/sugar3/graphics/palettemenu.py
+++ b/src/sugar3/graphics/palettemenu.py
@@ -1,4 +1,5 @@
 # Copyright 2012 One Laptop Per Child
+# Copyright 2014 Ignacio Rodriguez
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -98,14 +99,14 @@ class PaletteMenuItem(Gtk.EventBox):
 
         if icon_name is not None:
             self.icon = Icon(icon_name=icon_name,
-                             icon_size=Gtk.IconSize.SMALL_TOOLBAR)
+                             pixel_size=style.SMALL_ICON_SIZE)
             if xo_color is not None:
                 self.icon.props.xo_color = xo_color
             self._hbox.pack_start(self.icon, expand=False, fill=False,
                                   padding=style.DEFAULT_PADDING)
         elif file_name is not None:
             self.icon = Icon(file=file_name,
-                             icon_size=Gtk.IconSize.SMALL_TOOLBAR)
+                             pixel_size=style.SMALL_ICON_SIZE)
             if xo_color is not None:
                 self.icon.props.xo_color = xo_color
             self._hbox.pack_start(self.icon, expand=False, fill=False,

--- a/src/sugar3/graphics/radiotoolbutton.py
+++ b/src/sugar3/graphics/radiotoolbutton.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2007, Red Hat, Inc.
 # Copyright (C) 2007-2008, One Laptop Per Child
+# Copyright (C) 2014, Ignacio Rodriguez
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -23,6 +24,7 @@ STABLE.
 from gi.repository import Gtk
 from gi.repository import GObject
 
+from sugar3.graphics import style
 from sugar3.graphics.icon import Icon
 from sugar3.graphics.palette import Palette, ToolInvoker
 from sugar3.graphics import toolbutton
@@ -46,7 +48,10 @@ class RadioToolButton(Gtk.RadioToolButton):
         self._palette_invoker.attach_tool(self)
 
         if icon_name:
-            self.set_icon_name(icon_name)
+            icon = Icon(icon_name=icon_name,
+                        pixel_size=style.STANDARD_ICON_SIZE)
+            self.set_icon_widget(icon)
+            icon.show()
 
         self.connect('destroy', self.__destroy_cb)
 
@@ -83,7 +88,7 @@ class RadioToolButton(Gtk.RadioToolButton):
 
     def set_icon_name(self, icon_name):
         icon = Icon(icon_name=icon_name,
-                    xo_color=self._xo_color)
+                    pixel_size=style.STANDARD_ICON_SIZE)
         self.set_icon_widget(icon)
         icon.show()
 

--- a/src/sugar3/graphics/toggletoolbutton.py
+++ b/src/sugar3/graphics/toggletoolbutton.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2007, Red Hat, Inc.
 # Copyright (C) 2012, Daniel Francis
+# Copyright (C) 2014, Ignacio Rodriguez
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -25,6 +26,7 @@ import logging
 from gi.repository import GObject
 from gi.repository import Gtk
 
+from sugar3.graphics import style
 from sugar3.graphics.icon import Icon
 from sugar3.graphics.palette import Palette, ToolInvoker
 
@@ -67,7 +69,10 @@ class ToggleToolButton(Gtk.ToggleToolButton):
         self._palette_invoker = ToolInvoker(self)
 
         if icon_name:
-            self.set_icon_name(icon_name)
+            icon = Icon(icon_name=icon_name,
+                        pixel_size=style.STANDARD_ICON_SIZE)
+            self.set_icon_widget(icon)
+            icon.show()
 
         self.connect('destroy', self.__destroy_cb)
 
@@ -76,7 +81,8 @@ class ToggleToolButton(Gtk.ToggleToolButton):
             self._palette_invoker.detach()
 
     def set_icon_name(self, icon_name):
-        icon = Icon(icon_name=icon_name)
+        icon = Icon(icon_name=icon_name,
+                    pixel_size=style.STANDARD_ICON_SIZE)
         self.set_icon_widget(icon)
         icon.show()
 

--- a/src/sugar3/graphics/toolbutton.py
+++ b/src/sugar3/graphics/toolbutton.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2007, Red Hat, Inc.
 # Copyright (C) 2008, One Laptop Per Child
+# Copyright (C) 2014, Ignacio Rodriguez
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -25,6 +26,7 @@ import logging
 from gi.repository import Gtk
 from gi.repository import GObject
 
+from sugar3.graphics import style
 from sugar3.graphics.icon import Icon
 from sugar3.graphics.palette import Palette, ToolInvoker
 
@@ -72,7 +74,10 @@ class ToolButton(Gtk.ToolButton):
         self._palette_invoker.attach_tool(self)
 
         if icon_name:
-            self.set_icon_name(icon_name)
+            icon = Icon(icon_name=icon_name,
+                        pixel_size=style.STANDARD_ICON_SIZE)
+            self.set_icon_widget(icon)
+            icon.show()
 
         self.get_child().connect('can-activate-accel',
                                  self.__button_can_activate_accel_cb)
@@ -128,7 +133,8 @@ class ToolButton(Gtk.ToolButton):
                                    getter=get_accelerator)
 
     def set_icon_name(self, icon_name):
-        icon = Icon(icon_name=icon_name)
+        icon = Icon(icon_name=icon_name,
+                    pixel_size=style.STANDARD_ICON_SIZE)
         self.set_icon_widget(icon)
         icon.show()
 

--- a/src/sugar3/graphics/tray.py
+++ b/src/sugar3/graphics/tray.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2007, One Laptop Per Child
+# Copyright (C) 2014, Ignacio Rodriguez
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -188,7 +189,7 @@ class _TrayScrollButton(ToolButton):
         self.set_size_request(style.GRID_CELL_SIZE, style.GRID_CELL_SIZE)
 
         self.icon = Icon(icon_name=icon_name,
-                         icon_size=Gtk.IconSize.SMALL_TOOLBAR)
+                         pixel_size=style.SMALL_ICON_SIZE)
         # The alignment is a hack to work around Gtk.ToolButton code
         # that sets the icon_size when the icon_widget is a Gtk.Image
         alignment = Gtk.Alignment(xalign=0.5, yalign=0.5)
@@ -435,7 +436,7 @@ class _IconWidget(Gtk.EventBox):
                         Gdk.EventMask.BUTTON_RELEASE_MASK)
 
         self._icon = Icon(icon_name=icon_name, xo_color=xo_color,
-                          icon_size=Gtk.IconSize.LARGE_TOOLBAR)
+                          pixel_size=style.STANDARD_ICON_SIZE)
         self.add(self._icon)
         self._icon.show()
 

--- a/src/sugar3/graphics/window.py
+++ b/src/sugar3/graphics/window.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2007, Red Hat, Inc.
 # Copyright (C) 2009, Aleksey Lim, Sayamindu Dasgupta
+# Copyright (C) 2014, Ignacio Rodriguez
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -26,6 +27,7 @@ from gi.repository import Gdk
 from gi.repository import GdkX11
 from gi.repository import Gtk
 
+from sugar3.graphics import style
 from sugar3.graphics.icon import Icon
 from sugar3.graphics import palettegroup
 
@@ -47,7 +49,7 @@ class UnfullscreenButton(Gtk.Window):
         self.props.accept_focus = False
 
         # Setup estimate of width, height
-        valid_, w, h = Gtk.icon_size_lookup(Gtk.IconSize.LARGE_TOOLBAR)
+        valid_, w, h = Gtk.icon_size_lookup(style.STANDARD_ICON_SIZE)
         self._width = w
         self._height = h
 
@@ -58,7 +60,7 @@ class UnfullscreenButton(Gtk.Window):
         self._button.set_relief(Gtk.ReliefStyle.NONE)
 
         self._icon = Icon(icon_name='view-return',
-                          icon_size=Gtk.IconSize.LARGE_TOOLBAR)
+                          pixel_size=style.STANDARD_ICON_SIZE)
         self._icon.show()
         self._button.add(self._icon)
 


### PR DESCRIPTION
Remove Gtk.IconSize from toolkit, this  restore the 'Icon Scale' on Gtk 3.10
