### PR TITLE
Keep updated CellRendererInvoker self.path updated - Fixes #4717

### DIFF
--- a/src/sugar3/graphics/palettewindow.py
+++ b/src/sugar3/graphics/palettewindow.py
@@ -1487,12 +1487,13 @@ class CellRendererInvoker(Invoker):
         if pos is None:
             return False
 
-        path_, column, x, y_ = pos
+        path, column, x, y_ = pos
 
         for cell_renderer in column.get_cells():
             if cell_renderer == self._cell_renderer:
                 cell_x, cell_width = column.cell_get_position(cell_renderer)
                 if x > cell_x and x < (cell_x + cell_width):
+                    self.path = path
                     return True
                 return False
 


### PR DESCRIPTION
Since CellRendererInvoker can set the path at None if a mouse event
is out of the area of the renderer, can break the use of touch,
if happen after the mouse movement. This patch set the path,
in the point_in_cell_renderer test, for the positive case,
solving the issue.

Signed-off-by: Gonzalo Odiard godiard@sugarlabs.org
