### PR TITLE
Fixes #2316, abort bundle install when there is not enough disk space

### DIFF
--- a/src/sugar3/bundle/bundle.py
+++ b/src/sugar3/bundle/bundle.py
@@ -25,7 +25,7 @@ import logging
 import shutil
 import StringIO
 import zipfile
-
+import subprocess
 
 class AlreadyInstalledException(Exception):
     pass
@@ -170,6 +170,25 @@ class Bundle(object):
 
         if not os.path.isdir(install_dir):
             os.mkdir(install_dir, 0775)
+
+        z_obj = zipfile.ZipFile(self._path)
+        z_bytes = 0
+        for i in z_obj.infolist():
+            z_bytes += i.file_size
+        z_kb = float(z_bytes) / 1000
+        # Make room for some overhead
+        z_kb *= 1.1
+
+        df_process = subprocess.Popen(['df', install_dir],
+                                      stdout=subprocess.PIPE)
+        df_out = df_process.communicate()[0]
+        df_data = df_out.split('\n')[1].split()
+        kb_left = int(df_data[3])
+
+        logging.error('{} > {}?'.format(z_kb, kb_left))
+        
+        if z_kb > kb_left:
+            raise ZipExtractException("Not enough space")
 
         # zipfile provides API that in theory would let us do this
         # correctly by hand, but handling all the oddities of


### PR DESCRIPTION
I'm not sure if more is needed here: should we tell the user that they are out of space, or should we even tell them there was an error (I don't think we do). I'm really starting to think we need a simple notification system, maybe a simple popup in the corner thing.
