### PR TITLE
Webkit1 compatibility: send 404 error if the file don't exists

### DIFF
--- a/src/sugar3/activity/webkit1.py
+++ b/src/sugar3/activity/webkit1.py
@@ -46,6 +46,8 @@ class LocalRequestHandler(BaseHTTPRequestHandler):
         new_path = self.server.path + '/' + self.path
         if not os.path.exists(new_path):
             logging.error('file %s not found.', new_path)
+            self.send_response(404)
+            self.end_headers()
             return False
 
         with open(new_path) as f:


### PR DESCRIPTION
Signed-off-by: Gonzalo Odiard godiard@sugarlabs.org
