### PR TITLE
Fixes #2316, pass n to unzip so errors are aborted

### DIFF
--- a/src/sugar3/bundle/bundle.py
+++ b/src/sugar3/bundle/bundle.py
@@ -25,6 +25,7 @@ import logging
 import shutil
 import StringIO
 import zipfile
+import subprocess
 
 
 class AlreadyInstalledException(Exception):
@@ -175,8 +176,11 @@ class Bundle(object):
         # correctly by hand, but handling all the oddities of
         # Windows/UNIX mappings, extension attributes, deprecated
         # features, etc makes it impractical.
-        if os.spawnlp(os.P_WAIT, 'unzip', 'unzip', '-o', self._path,
-                      '-x', 'mimetype', '-d', install_dir):
+        process = subprocess.Popen(['unzip', '-o', self._path, '-x',
+                        'mimetype', '-d', install_dir], stdin=subprocess.PIPE)
+        process.stdin.write('n\n'*5)
+        return_code = process.wait()
+        if return_code:
             # clean up install dir after failure
             shutil.rmtree(os.path.join(install_dir, self._zip_root_dir),
                           ignore_errors=True)


### PR DESCRIPTION
I haven't tested this on a full disk :dvd:. It still works on a when I have 123Gb space left :smiley:. I haven't added notifications :exclamation:  yet, but I'm still working on those :clock10:.
