### PR TITLE
[Feature] Add verbosity to the unit tests in activities

### DIFF
--- a/src/sugar3/activity/bundlebuilder.py
+++ b/src/sugar3/activity/bundlebuilder.py
@@ -268,14 +268,14 @@ def cmd_check(config, args):
     """Run tests for the activity"""
 
     if len(args) > 1:
-        print "Usage: %prog check {integration.unit}"
+        print "Usage: %prog check {integration/unit/unit_verbose}"
         return
 
     run_unit_test = True
     run_integration_test = True
 
     if len(args) == 1:
-        if args[0] == "unit":
+        if (args[0] == "unit") or (args[0] == "unit_verbose"):
             run_integration_test = False
         elif args[0] == "integration":
             run_unit_test = False
@@ -294,7 +294,10 @@ def cmd_check(config, args):
         # Run Tests
         if os.path.isdir(unit_test_path) and run_unit_test:
             all_tests = unittest.defaultTestLoader.discover(unit_test_path)
-            unittest.TextTestRunner().run(all_tests)
+            if len(args)==1 and "unit_verbose" in args[0]:
+                unittest.TextTestRunner(verbosity=2).run(all_tests)
+            else:
+                unittest.TextTestRunner().run(all_tests)
         elif not run_unit_test:
             print "Not running unit tests"
         else:


### PR DESCRIPTION
Presently the tests of the activities can be run as follows:
./setup.py check
./setup.py check unit
./setup.py integration

The verbosity of the unit tests being run is the default value, so I changed it and added the option of unit_verbose, which run the unit tests with higher verbosity, so that the user can understand more from the tests run...

./setup.py check unit_verbose

I can add screenshots to show the Terminal Results, if required

Please Review...
--gp94
