### PR TITLE
[Feature] Notifications api for activities

### DIFF
--- a/src/sugar3/activity/activity.py
+++ b/src/sugar3/activity/activity.py
@@ -82,6 +82,7 @@ from sugar3.graphics.window import Window
 from sugar3.graphics.alert import Alert
 from sugar3.graphics.icon import Icon
 from sugar3.datastore import datastore
+from sugar3.bundle.activitybundle import ActivityBundle
 from gi.repository import SugarExt
 
 _ = lambda msg: gettext.dgettext('sugar-toolkit-gtk3', msg)
@@ -93,6 +94,10 @@ SCOPE_NEIGHBORHOOD = 'public'
 J_DBUS_SERVICE = 'org.laptop.Journal'
 J_DBUS_PATH = '/org/laptop/Journal'
 J_DBUS_INTERFACE = 'org.laptop.Journal'
+
+N_BUS_NAME = 'org.freedesktop.Notifications'
+N_OBJ_PATH = '/org/freedesktop/Notifications'
+N_IFACE_NAME = 'org.freedesktop.Notifications'
 
 CONN_INTERFACE_ACTIVITY_PROPERTIES = 'org.laptop.Telepathy.ActivityProperties'
 
@@ -632,6 +637,22 @@ class Activity(Window, Gtk.Container):
         this file_path.
         """
         raise NotImplementedError
+
+    def notify_user(self, summary, body, timeout=-1):
+        """
+        Display a notification with the given summary and body.
+        The notification will go under the activities icon in the frame.
+        """
+        bundle = ActivityBundle(get_bundle_path())
+        icon = bundle.get_icon()
+
+        bus = dbus.SessionBus()
+        notify_obj = bus.get_object(N_BUS_NAME, N_OBJ_PATH)
+        notifications = dbus.Interface(notify_obj, N_IFACE_NAME)
+
+        notifications.Notify(self.get_id(), 0, '', summary, body, [],
+                             {'x-sugar-icon-file-name': icon},
+                             timeout)
 
     def __save_cb(self):
         logging.debug('Activity.__save_cb')


### PR DESCRIPTION
The api is used like:

```
self.notify('Bob sent you DOGE 5',
            'Come back to your doge coin wallet to spend your DOGE!')
```

The api is found in activity.notify

This requires https://github.com/tchx84/sugar/pull/2 (which is built on https://github.com/sugarlabs/sugar/pull/267 FYI).
