### PR TITLE
error checking for activity id

### DIFF
--- a/src/sugar3/activity/activityservice.py
+++ b/src/sugar3/activity/activityservice.py
@@ -52,6 +52,11 @@ class ActivityService(dbus.service.Object):
         activity.realize()
 
         activity_id = activity.get_id()
+        if (activity_id is None):
+            logging.debug("activity %s" % activity)
+            raise Exception("Activity ID cannot be Null")
+
+        logging.debug("activity_id %s" % activity_id)
         service_name = _ACTIVITY_SERVICE_NAME + activity_id
         object_path = _ACTIVITY_SERVICE_PATH + '/' + activity_id
 


### PR DESCRIPTION
While testing porting over paint
got error that the activity get_id was returning null
added in a check, see also change requests for paint to get running
https://git.sugarlabs.org/~h4ck3rm1k3/paint/h4ck3rm1k3s-paint

see my standalone test instructions here 
https://github.com/h4ck3rm1k3/sugar-toolkit-gtk3/blob/standalone/README
