### PR TITLE
Now show sugar object choosers as file pickers in web activities

### DIFF
--- a/src/sugar3/activity/webkit1.py
+++ b/src/sugar3/activity/webkit1.py
@@ -36,6 +36,7 @@ import mimetypes
 
 from gi.repository import SugarExt
 from sugar3.activity import activity
+from sugar3.activity.webactivity import FilePicker
 
 
 class LocalRequestHandler(BaseHTTPRequestHandler):
@@ -135,6 +136,11 @@ class WebActivity(Gtk.Window):
                                self._loading_changed_cb)
         self._web_view.connect("resource-request-starting",
                                self._resource_request_starting_cb)
+        try:
+            self._web_view.connect('run-file-chooser', self.__run_file_chooser)
+        except TypeError:
+            # Only present in WebKit1 > 1.9.3 and WebKit2
+            pass
 
         self.add(self._web_view)
         self._web_view.show()
@@ -195,3 +201,12 @@ class WebActivity(Gtk.Window):
                     """ % env_json
 
             self._web_view.execute_script(script)
+
+    def __run_file_chooser(self, browser, request):
+        picker = FilePicker(self)
+        chosen = picker.run()
+        picker.destroy()
+
+        if chosen:
+            request.select_files([chosen])
+        return True


### PR DESCRIPTION
Hi,

Using the html5 file api is by far the easiest way to use files in a web activity, but it showed the gnome dialogue instead of the sugar one. This was fixed by almost copying code from browse :smile:.

Before:
![fixfileselectorbefore](https://cloud.githubusercontent.com/assets/6022042/2557300/52749e70-b6fc-11e3-9d2b-046eff148c4f.png)

After:
![image](https://cloud.githubusercontent.com/assets/6022042/2557296/14bbcf90-b6fc-11e3-9b0e-9d7e3848fe0e.png)

This is very basic, since webkit seemed to have issues with filters (`accept` attribute) :-1:.

Enjoy!
