### PR TITLE
Do web activity setup stuff when committed

### DIFF
--- a/src/sugar3/activity/webactivity.py
+++ b/src/sugar3/activity/webactivity.py
@@ -101,7 +101,7 @@ class WebActivity(Gtk.Window):
         Gtk.main_quit()
 
     def _loading_changed_cb(self, web_view, load_event):
-        if load_event == WebKit2.LoadEvent.FINISHED:
+        if load_event == WebKit2.LoadEvent.COMMITTED:
             key = os.environ["SUGAR_APISOCKET_KEY"]
             port = os.environ["SUGAR_APISOCKET_PORT"]
 

--- a/src/sugar3/activity/webkit1.py
+++ b/src/sugar3/activity/webkit1.py
@@ -176,7 +176,7 @@ class WebActivity(Gtk.Window):
 
         status = web_view.get_load_status()
 
-        if status == WebKit.LoadStatus.FINISHED:
+        if status == WebKit.LoadStatus.COMMITTED:
             key = os.environ["SUGAR_APISOCKET_KEY"]
             port = os.environ["SUGAR_APISOCKET_PORT"]
 


### PR DESCRIPTION
This is done so that random 404 errors don't result in the page never being 'loaded' by webkits definition - hence the activity never getting it's environment variable setup.

I tried to fix the 404 thing but LOL; request.finish_error only wants 1 arg but needs self and and the error xD
