### PR TITLE
Assign max_participants in activity.info

### DIFF
--- a/src/sugar3/activity/activity.py
+++ b/src/sugar3/activity/activity.py
@@ -495,6 +495,13 @@ class Activity(Window, Gtk.Container):
         type=bool, default=False, getter=get_active, setter=set_active)
 
     def get_max_participants(self):
+        # If max_participants has not been set in the activity, get it
+        # from the bundle.
+        if self._max_participants == 0:
+            bundle = ActivityBundle(get_bundle_path())
+            max_participants = bundle.get_max_participants()
+            if max_participants is not None:
+                self._max_participants = max_participants
         return self._max_participants
 
     def set_max_participants(self, participants):

--- a/src/sugar3/bundle/activitybundle.py
+++ b/src/sugar3/bundle/activitybundle.py
@@ -109,6 +109,7 @@ class ActivityBundle(Bundle):
         self._activity_version = '0'
         self._summary = None
         self._single_instance = False
+        self._max_participants = None
 
         info_file = self.get_file('activity/activity.info')
         if info_file is None:
@@ -186,6 +187,15 @@ class ActivityBundle(Bundle):
         if cp.has_option(section, 'single_instance'):
             if cp.get(section, 'single_instance') == 'yes':
                 self._single_instance = True
+
+        if cp.has_option(section, 'max_participants'):
+            max_participants = cp.get(section, 'max_participants')
+            try:
+                self._max_participants = int(max_participants)
+            except ValueError:
+                raise MalformedBundleException(
+                    'Activity bundle %s has invalid max_participants %s' %
+                    (self._path, max_participants))
 
     def _get_linfo_file(self):
         # Using method from gettext.py, first find languages from environ
@@ -290,6 +300,10 @@ class ActivityBundle(Bundle):
     def get_single_instance(self):
         """Get whether there should be a single instance for the activity"""
         return self._single_instance
+
+    def get_max_participants(self):
+        """Get maximum number of participants in share"""
+        return self._max_participants
 
     def get_show_launcher(self):
         """Get whether there should be a visible launcher for the activity"""


### PR DESCRIPTION
As part of an effort to "honor" max_participants, this patch supports setting
max_participants in activity.info, thus making it available in the bundle.

By default, if it is not set in the bundle, the previous behavior persists.
