### PR TITLE
Add Icon.get_badge_size

### DIFF
--- a/src/sugar3/graphics/icon.py
+++ b/src/sugar3/graphics/icon.py
@@ -514,6 +514,9 @@ class Icon(Gtk.Image):
     badge_name = GObject.property(
         type=str, getter=get_badge_name, setter=set_badge_name)
 
+    def get_badge_size(self):
+        return int(_BADGE_SIZE * self.props.pixel_size)
+
     def set_alpha(self, value):
         if self._alpha != value:
             self._alpha = value


### PR DESCRIPTION
Add get_badge_size method to Icon class, so it can be accessed
by other Icon sub-classes, instead of repeating code and accessing
private constants.

ie., jarabe.frame.notification.NotificationPulsingIcon.

Signed-off-by: Martin Abente Lahaye tch@sugarlabs.org
