### PR TITLE
Assign max_participants in activity.info

### DIFF
--- a/src/sugar3/activity/activity.py
+++ b/src/sugar3/activity/activity.py
@@ -82,7 +82,7 @@ from sugar3.graphics.window import Window
 from sugar3.graphics.alert import Alert
 from sugar3.graphics.icon import Icon
 from sugar3.datastore import datastore
-from sugar3.bundle.activitybundle import ActivityBundle
+from sugar3.bundle.activitybundle import get_bundle_instance
 from gi.repository import SugarExt
 
 _ = lambda msg: gettext.dgettext('sugar-toolkit-gtk3', msg)
@@ -334,7 +334,7 @@ class Activity(Window, Gtk.Container):
         self._closing = False
         self._quit_requested = False
         self._deleting = False
-        self._max_participants = 0
+        self._max_participants = None
         self._invites_queue = []
         self._jobject = None
         self._read_file_called = False
@@ -495,6 +495,11 @@ class Activity(Window, Gtk.Container):
         type=bool, default=False, getter=get_active, setter=set_active)
 
     def get_max_participants(self):
+        # If max_participants has not been set in the activity, get it
+        # from the bundle.
+        if self._max_participants is None:
+            bundle = get_bundle_instance(get_bundle_path())
+            self._max_participants = bundle.get_max_participants()
         return self._max_participants
 
     def set_max_participants(self, participants):
@@ -643,7 +648,7 @@ class Activity(Window, Gtk.Container):
         Display a notification with the given summary and body.
         The notification will go under the activities icon in the frame.
         """
-        bundle = ActivityBundle(get_bundle_path())
+        bundle = get_bundle_instance(get_bundle_path())
         icon = bundle.get_icon()
 
         bus = dbus.SessionBus()

--- a/src/sugar3/activity/widgets.py
+++ b/src/sugar3/activity/widgets.py
@@ -27,7 +27,7 @@ from sugar3.graphics.radiopalette import RadioPalette, RadioMenuButton
 from sugar3.graphics.radiotoolbutton import RadioToolButton
 from sugar3.graphics.xocolor import XoColor
 from sugar3.graphics.icon import Icon
-from sugar3.bundle.activitybundle import ActivityBundle
+from sugar3.bundle.activitybundle import get_bundle_instance
 from sugar3.graphics import style
 from sugar3.graphics.palettemenu import PaletteMenuBox
 from sugar3 import profile
@@ -43,7 +43,7 @@ def _create_activity_icon(metadata):
         color = profile.get_color()
 
     from sugar3.activity.activity import get_bundle_path
-    bundle = ActivityBundle(get_bundle_path())
+    bundle = get_bundle_instance(get_bundle_path())
     icon = Icon(file=bundle.get_icon(), xo_color=color)
 
     return icon


### PR DESCRIPTION
As part of an effort to "honor" max_participants, this patch supports setting
max_participants in activity.info, thus making it available in the bundle.

By default, if it is not set in the bundle, the previous behavior persists.

In support of this change, a cache of Activity bundles is
maintained. The goal is to eliminate unnecessary calls to the file
system.
