### PR TITLE
Avoid breaking activity startup by dbus timeout on sigle instance - Fixe...

### DIFF
--- a/bin/sugar-activity
+++ b/bin/sugar-activity
@@ -146,12 +146,17 @@ def main():
         if not name:
             SingleProcess(service_name, activity_constructor)
         else:
-            single_process = sessionbus.get_object(service_name, service_path)
-            single_process.create(activity_handle.get_dict(),
-                                  dbus_interface='org.laptop.SingleProcess')
+            try:
+                single_process = sessionbus.get_object(service_name,
+                                                       service_path)
+                single_process.create(
+                    activity_handle.get_dict(),
+                    dbus_interface='org.laptop.SingleProcess')
 
-            print 'Created %s in a single process.' % service_name
-            sys.exit(0)
+                print 'Created %s in a single process.' % service_name
+                sys.exit(0)
+            except (TypeError, dbus.DBusException):
+                print 'dbus error trying to start a single instance'
 
     if hasattr(module, 'start'):
         module.start()


### PR DESCRIPTION
...s #4773

This problem only happen in activities configured with the option -s
in the activity.info "exec" field, and the objective is use a single process,
even when starting more than one instance. If the process do not reply,
start a new process, instead of show a error.

Signed-off-by: Gonzalo Odiard godiard@sugarlabs.org
