### PR TITLE
Show palettes at the screen bottom with the right size - Fixes #4673

### DIFF
--- a/src/sugar3/graphics/palette.py
+++ b/src/sugar3/graphics/palette.py
@@ -276,6 +276,7 @@ class Palette(PaletteWindow):
             ELLIPSIS_LENGTH = 6
 
             label = label.replace('\n', ' ')
+            label = label.replace('\r', ' ')
 
             self._secondary_label.modify_fg(Gtk.StateType.INSENSITIVE,
                                             Gdk.color_parse('white'))

--- a/src/sugar3/graphics/palettewindow.py
+++ b/src/sugar3/graphics/palettewindow.py
@@ -612,10 +612,19 @@ class PaletteWindow(GObject.GObject):
             logging.error('Cannot update the palette position.')
             return
 
-        rect = self._widget.size_request()
-        position = invoker.get_position_for_alignment(self._alignment, rect)
+        req = self._widget.size_request()
+        # on Gtk 3.10, menu at the bottom of the screen are resized
+        # to not fall out, and report a wrong size.
+        # measure the children and move the menu - SL #4673
+        total_height = 0
+        for child in self._widget.get_children():
+            child_req = child.size_request()
+            total_height += child_req.height
+        req.height = total_height
+
+        position = invoker.get_position_for_alignment(self._alignment, req)
         if position is None:
-            position = invoker.get_position(rect)
+            position = invoker.get_position(req)
 
         self._widget.move(position.x, position.y)
 


### PR DESCRIPTION
On Gtk 3.10, Gtk.Menu at the bottom of the screen are resized
to avoid fall out of the screen, then report a wrong height.
We need calculate the size of the children and move the Menu up.

This problem is visible on the Clipboard icon palettes,
and in journal objects palettes at the bottom of the screen.

This patch also rename a variable 'rect' to 'req', because is
a Requisition (width, height) and not a Rectangle (x, y, width, height).

Finally, to avoid a error with the secondary text on the palette,
when copy text from the terminal, reove the '¬r' character.

Signed-off-by: Gonzalo Odiard godiard@sugarlabs.org
