### PR TITLE
Fix drawing of gap on palettes attached to widget - Fixes #4776

### DIFF
--- a/src/sugar3/graphics/palettewindow.py
+++ b/src/sugar3/graphics/palettewindow.py
@@ -370,6 +370,12 @@ class _PaletteWindowWidget(Gtk.Window):
         context = self.get_style_context()
         context.add_class('toolitem')
         if gap:
+            cr.save()
+            cr.set_source_rgb(0, 0, 0)
+            cr.rectangle(0, 0, allocation.width, allocation.height)
+            cr.set_line_width(4)
+            cr.stroke()
+            cr.restore()
             Gtk.render_frame_gap(
                 context, cr, 0, 0, allocation.width, allocation.height,
                 gap[0], gap[1], gap[1] + gap[2])


### PR DESCRIPTION
In Gtk 3.10, Gtk.Window is drawing a gray border around the palette.
This patch draw a black rectangle defore we draw Gtk.render_frame_gap
to draw the border but with a gap to connect to the attached widget.

Signed-off-by: Gonzalo Odiard godiard@sugarlabs.org
