### PR TITLE
Remove a double / in webkit1 activity's request's filenames

### DIFF
--- a/src/sugar3/activity/webkit1.py
+++ b/src/sugar3/activity/webkit1.py
@@ -43,7 +43,7 @@ class LocalRequestHandler(BaseHTTPRequestHandler):
 
     # Handler for the GET requests
     def do_GET(self):
-        new_path = self.server.path + '/' + self.path
+        new_path = self.server.path + self.path
         if not os.path.exists(new_path):
             logging.error('file %s not found.', new_path)
             self.send_response(404)


### PR DESCRIPTION
The activity was trying to load files like `/home/olpc/Activities/Slides.activity//index.html` which didn't work.

Now it loads it without 2 slashes :smile:
