### PR TITLE
Enable collaboration by default on activities

### DIFF
--- a/src/sugar3/bundle/activitybundle.py
+++ b/src/sugar3/bundle/activitybundle.py
@@ -113,7 +113,7 @@ class ActivityBundle(Bundle):
         self._activity_version = '0'
         self._summary = None
         self._single_instance = False
-        self._max_participants = 1
+        self._max_participants = 0
 
         info_file = self.get_file('activity/activity.info')
         if info_file is None:


### PR DESCRIPTION
When we implemented read max_participants from activity.info [1]
we changed the default value of max_participants, from 0 to 1.
Before, was responsability of the activities set max_participants == 1,
when the activity not implemented collaboration.
This change make the default backwards compatible.

[1] d0cca91fe8510e11de8f332bf659789daf9c0d8d
