### PR TITLE
Remove Palette logic out of PaletteWindow

### DIFF
--- a/src/sugar3/graphics/palette.py
+++ b/src/sugar3/graphics/palette.py
@@ -456,6 +456,15 @@ class Palette(PaletteWindow):
 
     menu = GObject.property(type=object, getter=get_menu)
 
+    def _invoker_right_click_cb(self, invoker):
+        self.popup(immediate=True, state=self.SECONDARY)
+
+    def _invoker_toggle_state_cb(self, invoker):
+        if self.is_up() and self._palette_state == self.SECONDARY:
+            self.popdown(immediate=True)
+        else:
+            self.popup(immediate=True, state=self.SECONDARY)
+
 
 class PaletteActionBar(Gtk.HButtonBox):
 

--- a/src/sugar3/graphics/palettewindow.py
+++ b/src/sugar3/graphics/palettewindow.py
@@ -700,13 +700,10 @@ class PaletteWindow(GObject.GObject):
             self.on_invoker_leave()
 
     def _invoker_right_click_cb(self, invoker):
-        self.popup(immediate=True, state=self.SECONDARY)
+        self.popup(immediate=True)
 
     def _invoker_toggle_state_cb(self, invoker):
-        if self.is_up() and self._palette_state == self.SECONDARY:
-            self.popdown(immediate=True)
-        else:
-            self.popup(immediate=True, state=self.SECONDARY)
+        self.popdown(immediate=True)
 
     def __enter_notify_cb(self, widget):
         if not self._invoker.locked:


### PR DESCRIPTION
PaletteWindow is the parent class of two different subclases,
Palette and _ToolBarPalette. Palette uses state changes intensively
in order to display secondary content, but _ToolBarPalette does not.

Because of this, Palette overwrites PaletteWindow's popup and popdown
methods adding one extra param called "state". This param is not required
either in PaletteWindow and specially not in _ToolBarPalette.

Therefore, any piece of code inside PaletteWindow which is meant for
Palette subclassing, should be moved out of PaletteWindow and placed
in the Palette class, where it corresponds.

This patch fixes the cases where _ToolBarPalette breaks because of this
mismatch.

Signed-off-by: Martin Abente Lahaye tch@sugarlabs.org
