### PR TITLE
BundleBuilder: Don't crash on malformed translation files

### DIFF
--- a/src/sugar3/activity/bundlebuilder.py
+++ b/src/sugar3/activity/bundlebuilder.py
@@ -137,6 +137,8 @@ class Builder(object):
             retcode = subprocess.call(args)
             if retcode:
                 print 'ERROR - msgfmt failed with return code %i.' % retcode
+                print 'Continuing build without %s translation' % lang
+                continue
 
             cat = gettext.GNUTranslations(open(mo_file, 'r'))
             translated_name = cat.gettext(self.config.activity_name)


### PR DESCRIPTION
The BundleBuilder currently crashes on a malformed translation
file.  This is good for humans (makes them fix their issues) but
crashes bots who need it compiled and don't care about that
single translation file.
