### PR TITLE
Bundlebuilder check if activity files are in git

### DIFF
--- a/src/sugar3/activity/bundlebuilder.py
+++ b/src/sugar3/activity/bundlebuilder.py
@@ -178,9 +178,12 @@ class Packager(object):
                          'fall back to filtered list')
             return list_files(self.config.source_dir,
                               IGNORE_DIRS, IGNORE_FILES)
-
-        # pylint: disable=E1103
-        return [path.strip() for path in stdout.strip('\n').split('\n')]
+        if stdout:
+            # pylint: disable=E1103
+            return [path.strip() for path in stdout.strip('\n').split('\n')]
+        else:
+            return list_files(self.config.source_dir,
+                              IGNORE_DIRS, IGNORE_FILES)
 
 
 class XOPackager(Packager):


### PR DESCRIPTION
git version 1.9.3, in a activity directory created inside sugar-build/activities
return a empty string when the command "git ls-files" is executed,
and no repository is configured.
We need verify that condition, and process a file list from the filesystem.
