### PR TITLE
BundleBuilder: Don't crash on malformed translation files

### DIFF
--- a/src/sugar3/activity/bundlebuilder.py
+++ b/src/sugar3/activity/bundlebuilder.py
@@ -103,8 +103,9 @@ class Config(object):
 
 class Builder(object):
 
-    def __init__(self, config):
+    def __init__(self, config, no_fail=False):
         self.config = config
+        self._no_fail = no_fail
         self.locale_dir = os.path.join(self.config.build_dir, 'locale')
 
     def build(self):
@@ -137,6 +138,8 @@ class Builder(object):
             retcode = subprocess.call(args)
             if retcode:
                 print 'ERROR - msgfmt failed with return code %i.' % retcode
+                if self._no_fail:
+                    continue
 
             cat = gettext.GNUTranslations(open(mo_file, 'r'))
             translated_name = cat.gettext(self.config.activity_name)
@@ -326,7 +329,7 @@ def cmd_dev(config, options):
 def cmd_dist_xo(config, options):
     """Create a xo bundle package"""
 
-    packager = XOPackager(Builder(config))
+    packager = XOPackager(Builder(config, options.no_fail))
     packager.package()
 
 
@@ -424,7 +427,12 @@ def start():
                               default=1, nargs='?',
                               help="verbosity for the unit tests")
 
-    subparsers.add_parser("dist_xo", help="Create a xo bundle package")
+    dist_parser = subparsers.add_parser("dist_xo",
+                                         help="Create a xo bundle package")
+    dist_parser.add_argument("--no-fail", dest="no_fail", action="store_true",
+                             default=False,
+                             help="continue past failure when building xo file")
+
     subparsers.add_parser("dist_source", help="Create a tar source package")
     subparsers.add_parser("build", help="Build generated files")
     subparsers.add_parser(


### PR DESCRIPTION
Replaces #168 

The BundleBuilder currently crashes on a malformed translation file.  This is
good for humans (makes them fix their issues) but crashes bots who need it
compiled and don't care about that single translation file.

This patch adds a --no-fail option which stops the builder from crashing
