### PR TITLE
Get markup text as default

### DIFF
--- a/src/sugar3/graphics/palette.py
+++ b/src/sugar3/graphics/palette.py
@@ -24,6 +24,7 @@ STABLE.
 """
 import textwrap
 
+from gi.repository import GLib
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GObject
@@ -246,11 +247,13 @@ class Palette(PaletteWindow):
         self._label.props.accel_widget = self.props.invoker.props.widget
 
     def set_primary_text(self, label, accel_path=None):
-        self._primary_text = label
-
         if label is not None:
+            label = GLib.markup_escape_text(label)
             self._label.set_markup('<b>%s</b>' % label)
             self._label.show()
+
+        self._primary_text = label
+
 
     def get_primary_text(self):
         return self._primary_text
@@ -269,6 +272,7 @@ class Palette(PaletteWindow):
         else:
             NO_OF_LINES = 3
             ELLIPSIS_LENGTH = 6
+            label = GLib.markup_escape_text(label)
 
             label = label.replace('\n', ' ')
             label = label.replace('\r', ' ')
@@ -289,7 +293,7 @@ class Palette(PaletteWindow):
                 label = textwrap.fill(label, width=style.MENU_WIDTH_CHARS)
 
             self._secondary_text = label
-            self._secondary_label.set_text(label)
+            self._secondary_label.set_markup(label)
             self._secondary_label.show()
 
     def get_secondary_text(self):


### PR DESCRIPTION
Now sugar-toolkit get markup (glib.markup_escape_text) as default. This prevent non-human-readable html code showed in palettes.

This fixes SL#4456
