### PR TITLE
Raise the palette window when its mapped

### DIFF
--- a/src/sugar3/graphics/palette.py
+++ b/src/sugar3/graphics/palette.py
@@ -184,6 +184,11 @@ class Palette(PaletteWindow):
     def _setup_widget(self):
         PaletteWindow._setup_widget(self)
         self._widget.connect('destroy', self.__destroy_cb)
+        self._widget.connect('map', self.__map_cb)
+
+    def __map_cb(self, *args):
+        # Fixes #4463
+        self._widget.present()
 
     def __destroy_cb(self, palette):
         self._secondary_anim.stop()


### PR DESCRIPTION
This patch raise the palette window when its mapped
Its use: Gtk.Window.present [1] the user will
be able to saw the palette now when your apply the
test case of #4463

[1] https://developer.gnome.org/gtk3/stable/GtkWindow.html#gtk-window-present
Fixes #4463