### PR TITLE
Fix the badge location for icons

### DIFF
--- a/src/sugar3/graphics/icon.py
+++ b/src/sugar3/graphics/icon.py
@@ -202,8 +202,8 @@ class _IconBuffer(object):
             return info
 
         info.size = int(_BADGE_SIZE * icon_width)
-        info.attach_x = int(icon_info.attach_x * icon_width - info.size / 2)
-        info.attach_y = int(icon_info.attach_y * icon_height - info.size / 2)
+        info.attach_x = int(icon_info.attach_x * icon_width  / 2)
+        info.attach_y = int(icon_info.attach_y * icon_height / 2)
 
         if info.attach_x < 0 or info.attach_y < 0:
             info.icon_padding = max(-info.attach_x, -info.attach_y)


### PR DESCRIPTION
This is visibly an issue where the badge goes outside the bounds of
the icons.  For example, before this patch the wifi icons look like
this:

[![Gyazo](http://i.gyazo.com/5501940192d95d9df59323d0ddc45af6.png)](http://gyazo.com/5501940192d95d9df59323d0ddc45af6)

Whereas, after the patch:

[![Gyazo](http://i.gyazo.com/f5780d29bf18f82b1ea3a2844297afce.png)](http://gyazo.com/f5780d29bf18f82b1ea3a2844297afce)