### PR TITLE
Don't break activity startup if .info have 'class' instead of 'exec'

### DIFF
--- a/src/sugar3/bundle/activitybundle.py
+++ b/src/sugar3/bundle/activitybundle.py
@@ -101,7 +101,6 @@ class ActivityBundle(Bundle):
 
     def __init__(self, path, translated=True):
         Bundle.__init__(self, path)
-        self.activity_class = None
         self.bundle_exec = None
 
         self._name = None
@@ -158,9 +157,15 @@ class ActivityBundle(Bundle):
         if cp.has_option(section, 'exec'):
             self.bundle_exec = cp.get(section, 'exec')
         else:
-            raise MalformedBundleException(
-                'Activity bundle %s must specify either class or exec' %
-                self._path)
+            if cp.has_option(section, 'class'):
+                self.bundle_exec = 'sugar-activity ' + cp.get(section,
+                                                              'class')
+                logging.error('ATTENTION: class property in the '
+                              'activity.info file is deprecated, should be '
+                              'changed to exec')
+            else:
+                raise MalformedBundleException(
+                    'Activity bundle %s must specify exec' % self._path)
 
         if cp.has_option(section, 'mime_types'):
             mime_list = cp.get(section, 'mime_types').strip(';')
@@ -287,12 +292,7 @@ class ActivityBundle(Bundle):
 
     def get_command(self):
         """Get the command to execute to launch the activity factory"""
-        if self.bundle_exec:
-            command = os.path.expandvars(self.bundle_exec)
-        else:
-            command = 'sugar-activity ' + self.activity_class
-
-        return command
+        return os.path.expandvars(self.bundle_exec)
 
     def get_mime_types(self):
         """Get the MIME types supported by the activity"""


### PR DESCRIPTION
When we ported sugar to Gtk3 we removed the support of the fields
exec and service_name due they were deprecated for a long time [1].
But this is still a problem in deployments, and we already added
compatibility for the service_name field.
Here [3] there is a long thred were we discussed this issue.

[1] ae85dd62d42a7d5bea76aec3b941ce35ccc61bf4
[2] 32f97b48c31f60f306854753a3df734f63b798fc
[3] http://lists.sugarlabs.org/archive/sugar-devel/2013-October/045404.html