### PR TITLE
Bundle launcher

### DIFF
--- a/src/sugar3/activity/activity.py
+++ b/src/sugar3/activity/activity.py
@@ -1091,3 +1091,10 @@ def show_object_in_journal(object_id):
     obj = bus.get_object(J_DBUS_SERVICE, J_DBUS_PATH)
     journal = dbus.Interface(obj, J_DBUS_INTERFACE)
     journal.ShowObject(object_id)
+
+def launch_bundle(bundle_id="", object_id="", mime_type=""):
+    bus = dbus.SessionBus()
+    obj = bus.get_object('org.sugarlabs.BundleLauncher',
+                         '/org/sugarlabs/BundleLauncher')
+    bundle_launcher = dbus.Interface(obj, 'org.sugarlabs.BundleLauncher')
+    bundle_launcher.launch(bundle_id, object_id, mime_type)

--- a/src/sugar3/activity/activity.py
+++ b/src/sugar3/activity/activity.py
@@ -149,6 +149,7 @@ class _ActivitySession(GObject.GObject):
 
 
 class Activity(Window, Gtk.Container):
+
     """This is the base Activity class that all other Activities derive from.
        This is where your activity starts.
 
@@ -431,11 +432,11 @@ class Activity(Window, Gtk.Container):
     def _set_up_sharing(self, mesh_instance, share_scope):
         # handle activity share/join
         logging.debug('*** Act %s, mesh instance %r, scope %s' %
-                     (self._activity_id, mesh_instance, share_scope))
+                      (self._activity_id, mesh_instance, share_scope))
         if mesh_instance is not None:
             # There's already an instance on the mesh, join it
             logging.debug('*** Act %s joining existing mesh instance %r' %
-                         (self._activity_id, mesh_instance))
+                          (self._activity_id, mesh_instance))
             self.shared_activity = mesh_instance
             self.shared_activity.connect('notify::private',
                                          self.__privacy_changed_cb)
@@ -829,7 +830,7 @@ class Activity(Window, Gtk.Container):
     def __share_cb(self, ps, success, activity, err):
         if not success:
             logging.debug('Share of activity %s failed: %s.' %
-                         (self._activity_id, err))
+                          (self._activity_id, err))
             return
 
         logging.debug('Share of activity %s successful, PS activity is %r.' %
@@ -889,8 +890,9 @@ class Activity(Window, Gtk.Container):
             raise RuntimeError('Activity %s already shared.' %
                                self._activity_id)
         verb = private and 'private' or 'public'
-        logging.debug('Requesting %s share of activity %s.' % (verb,
-                      self._activity_id))
+        logging.debug(
+            'Requesting %s share of activity %s.' %
+            (verb, self._activity_id))
         pservice = presenceservice.get_instance()
         pservice.connect('activity-shared', self.__share_cb)
         pservice.share_activity(self, private=private)
@@ -1010,6 +1012,7 @@ class Activity(Window, Gtk.Container):
 
 
 class _ClientHandler(dbus.service.Object, DBusProperties):
+
     def __init__(self, bundle_id, got_channel_cb):
         self._interfaces = set([CLIENT, CLIENT_HANDLER, PROPERTIES_IFACE])
         self._got_channel_cb = got_channel_cb
@@ -1037,7 +1040,7 @@ class _ClientHandler(dbus.service.Object, DBusProperties):
         }
         filter_dict = dbus.Dictionary(filters, signature='sv')
         logging.debug('__get_filters_cb %r' % dbus.Array([filter_dict],
-                      signature='a{sv}'))
+                                                         signature='a{sv}'))
         return dbus.Array([filter_dict], signature='a{sv}')
 
     @dbus.service.method(dbus_interface=CLIENT_HANDLER,
@@ -1053,7 +1056,7 @@ class _ClientHandler(dbus.service.Object, DBusProperties):
                 handle_type = properties[CHANNEL + '.TargetHandleType']
                 if channel_type == CHANNEL_TYPE_TEXT:
                     self._got_channel_cb(connection, object_path, handle_type)
-        except Exception, e:
+        except Exception as e:
             logging.exception(e)
 
 _session = None
@@ -1091,6 +1094,7 @@ def show_object_in_journal(object_id):
     obj = bus.get_object(J_DBUS_SERVICE, J_DBUS_PATH)
     journal = dbus.Interface(obj, J_DBUS_INTERFACE)
     journal.ShowObject(object_id)
+
 
 def launch_bundle(bundle_id="", object_id="", mime_type=""):
     bus = dbus.SessionBus()

--- a/src/sugar3/activity/activityfactory.py
+++ b/src/sugar3/activity/activityfactory.py
@@ -134,10 +134,10 @@ def open_log_file(activity):
     while True:
         path = env.get_logs_path('%s-%s.log' % (activity.get_bundle_id(), i))
         try:
-            fd = os.open(path, os.O_EXCL | os.O_CREAT | os.O_WRONLY, 0644)
+            fd = os.open(path, os.O_EXCL | os.O_CREAT | os.O_WRONLY, 0o644)
             f = os.fdopen(fd, 'w', 0)
             return (path, f)
-        except OSError, e:
+        except OSError as e:
             if e.errno == EEXIST:
                 i += 1
             elif e.errno == ENOSPC:
@@ -148,6 +148,7 @@ def open_log_file(activity):
 
 
 class ActivityCreationHandler(GObject.GObject):
+
     """Sugar-side activity creation interface
 
     This object uses a dbus method on the ActivityFactory
@@ -200,11 +201,10 @@ class ActivityCreationHandler(GObject.GObject):
 
     def _launch_activity(self):
         if self._handle.activity_id is not None:
-            self._shell.ActivateActivity(self._handle.activity_id,
-                                         reply_handler=
-                                         self._activate_reply_handler,
-                                         error_handler=
-                                         self._activate_error_handler)
+            self._shell.ActivateActivity(
+                self._handle.activity_id,
+                reply_handler=self._activate_reply_handler,
+                error_handler=self._activate_error_handler)
         else:
             self._create_activity()
 

--- a/src/sugar3/activity/webkit1.py
+++ b/src/sugar3/activity/webkit1.py
@@ -41,7 +41,7 @@ from sugar3.activity import activity
 
 class LocalRequestHandler(BaseHTTPRequestHandler):
 
-    #Handler for the GET requests
+    # Handler for the GET requests
     def do_GET(self):
         new_path = self.server.path + '/' + self.path
         if not os.path.exists(new_path):
@@ -97,6 +97,7 @@ class LocalHTTPServer(HTTPServer):
 
 
 class WebActivity(Gtk.Window):
+
     def __init__(self, handle):
         Gtk.Window.__init__(self)
 

--- a/src/sugar3/bundle/contentbundle.py
+++ b/src/sugar3/bundle/contentbundle.py
@@ -34,6 +34,7 @@ from sugar3.bundle.bundleversion import InvalidVersionError
 
 
 class ContentBundle(Bundle):
+
     """A Sugar content bundle
 
     See http://wiki.laptop.org/go/Content_bundles for details
@@ -97,7 +98,7 @@ class ContentBundle(Bundle):
             self._icon = cp.get(section, 'icon')
 
         # Compatibility with old content bundles
-        if not self._global_name is None \
+        if self._global_name is not None \
                 and cp.has_option(section, 'bundle_class'):
             self._global_name = cp.get(section, 'bundle_class')
 

--- a/src/sugar3/datastore/datastore.py
+++ b/src/sugar3/datastore/datastore.py
@@ -76,6 +76,7 @@ _get_data_store()
 
 
 class DSMetadata(GObject.GObject):
+
     """A representation of the metadata associated with a DS entry."""
     __gsignals__ = {
         'updated': (GObject.SignalFlags.RUN_FIRST, None, ([])),
@@ -134,6 +135,7 @@ class DSMetadata(GObject.GObject):
 
 
 class DSObject(object):
+
     """A representation of a DS entry."""
 
     def __init__(self, object_id, metadata=None, file_path=None):
@@ -167,7 +169,7 @@ class DSObject(object):
         self._metadata.update(properties)
 
     def get_metadata(self):
-        if self._metadata is None and not self.object_id is None:
+        if self._metadata is None and self.object_id is not None:
             properties = _get_data_store().get_properties(self.object_id)
             metadata = DSMetadata(properties)
             self._metadata = metadata
@@ -180,7 +182,7 @@ class DSObject(object):
     metadata = property(get_metadata, set_metadata)
 
     def get_file_path(self, fetch=True):
-        if fetch and self._file_path is None and not self.object_id is None:
+        if fetch and self._file_path is None and self.object_id is not None:
             self.set_file_path(_get_data_store().get_filename(self.object_id))
             self._owns_file = True
         return self._file_path
@@ -217,6 +219,7 @@ class DSObject(object):
 
 
 class RawObject(object):
+
     """A representation for objects not in the DS but
     in the file system.
 

--- a/src/sugar3/graphics/icon.py
+++ b/src/sugar3/graphics/icon.py
@@ -257,7 +257,7 @@ class _IconBuffer(object):
         # document-generic. If that doesn't work out, bail.
         icon_width = None
         for (file_name, icon_name) in ((self.file_name, self.icon_name),
-                                      (None, 'document-generic')):
+                                       (None, 'document-generic')):
             icon_info = self._get_icon_info(file_name, icon_name)
             if icon_info.file_name is None:
                 return None
@@ -337,7 +337,7 @@ class Icon(Gtk.Image):
 
     __gtype_name__ = 'SugarIcon'
 
-    #FIXME: deprecate icon_size
+    # FIXME: deprecate icon_size
     _MENU_SIZES = (Gtk.IconSize.MENU, Gtk.IconSize.DND,
                    Gtk.IconSize.SMALL_TOOLBAR, Gtk.IconSize.BUTTON)
 
@@ -350,7 +350,7 @@ class Icon(Gtk.Image):
         self._alpha = 1.0
         self._scale = 1.0
 
-        #FIXME: deprecate icon_size
+        # FIXME: deprecate icon_size
         if 'icon_size' in kwargs:
             logging.warning("icon_size is deprecated. Use pixel_size instead.")
 
@@ -372,7 +372,7 @@ class Icon(Gtk.Image):
         if self._buffer.file_name != self.props.file:
             self._buffer.file_name = self.props.file
 
-        #FIXME: deprecate icon_size
+        # FIXME: deprecate icon_size
         pixel_size = None
         if self.props.pixel_size == -1:
             if self.props.icon_size in self._MENU_SIZES:
@@ -434,9 +434,9 @@ class Icon(Gtk.Image):
 
         allocation = self.get_allocation()
         x = math.floor(xpad +
-                      (allocation.width - requisition.width) * xalign)
+                       (allocation.width - requisition.width) * xalign)
         y = math.floor(ypad +
-                      (allocation.height - requisition.height) * yalign)
+                       (allocation.height - requisition.height) * yalign)
 
         if self._scale != 1.0:
             cr.scale(self._scale, self._scale)
@@ -513,6 +513,7 @@ class Icon(Gtk.Image):
 
 
 class EventIcon(Gtk.EventBox):
+
     """
     An Icon class that provides access to mouse events and that can act as a
     cursor-positioned palette invoker.
@@ -719,6 +720,7 @@ class EventIcon(Gtk.EventBox):
 
 
 class CanvasIcon(EventIcon):
+
     """
     An EventIcon with active and prelight states, and a styleable
     background.

--- a/src/sugar3/graphics/palettegroup.py
+++ b/src/sugar3/graphics/palettegroup.py
@@ -75,7 +75,7 @@ class Group(GObject.GObject):
         self._sig_ids[palette].append(sid)
 
     def remove(self, palette):
-        if not palette in self._palettes:
+        if palette not in self._palettes:
             # This happens when converting a window based palette to a menu
             # based one.
             return

--- a/src/sugar3/graphics/toolbarbox.py
+++ b/src/sugar3/graphics/toolbarbox.py
@@ -171,7 +171,7 @@ class ToolbarBox(Gtk.VBox):
         return self.toolbar.get_nth_item(self._expanded_button_index)
 
     def set_expanded_button(self, button):
-        if not button in self.toolbar:
+        if button not in self.toolbar:
             self._expanded_button_index = -1
             return
         self._expanded_button_index = self.toolbar.get_item_index(button)

--- a/src/sugar3/presence/activity.py
+++ b/src/sugar3/presence/activity.py
@@ -50,6 +50,7 @@ _logger = logging.getLogger('sugar3.presence.activity')
 
 
 class Activity(GObject.GObject):
+
     """UI interface for an Activity in the presence service
 
     Activities in the presence service represent your and other user's
@@ -114,7 +115,7 @@ class Activity(GObject.GObject):
         self._joined_buddies = {}
 
         self._get_properties_call = None
-        if not self.room_handle is None:
+        if self.room_handle is not None:
             self._start_tracking_properties()
 
     def _start_tracking_properties(self):
@@ -139,7 +140,7 @@ class Activity(GObject.GObject):
 
     def __activity_properties_changed_cb(self, room_handle, properties):
         _logger.debug('%r: Activity properties changed to %r' % (self,
-                      properties))
+                                                                 properties))
         self._update_properties(properties)
 
     def __got_properties_cb(self, properties):
@@ -295,8 +296,9 @@ class Activity(GObject.GObject):
         channel.connect_to_signal('Closed', self.__text_channel_closed_cb)
 
     def __get_all_members_cb(self, members, local_pending, remote_pending):
-        _logger.debug('__get_all_members_cb %r %r' % (members,
-                      self._text_channel_group_flags))
+        _logger.debug(
+            '__get_all_members_cb %r %r' %
+            (members, self._text_channel_group_flags))
         if self._channel_self_handle in members:
             members.remove(self._channel_self_handle)
 
@@ -390,7 +392,7 @@ class Activity(GObject.GObject):
         self._join_command.run()
 
     def share(self, share_activity_cb, share_activity_error_cb):
-        if not self.room_handle is None:
+        if self.room_handle is not None:
             raise ValueError('Already have a room handle')
 
         self._share_command = _ShareCommand(self.telepathy_conn, self._id)
@@ -494,6 +496,7 @@ class _BaseCommand(GObject.GObject):
 
 
 class _ShareCommand(_BaseCommand):
+
     def __init__(self, connection, activity_id):
         _BaseCommand.__init__(self)
 
@@ -547,6 +550,7 @@ class _ShareCommand(_BaseCommand):
 
 
 class _JoinCommand(_BaseCommand):
+
     def __init__(self, connection, room_handle):
         _BaseCommand.__init__(self)
 
@@ -616,8 +620,9 @@ class _JoinCommand(_BaseCommand):
         self._add_self_to_channel()
 
     def __text_channel_group_flags_changed_cb(self, added, removed):
-        _logger.debug('__text_channel_group_flags_changed_cb %r %r' % (added,
-                      removed))
+        _logger.debug(
+            '__text_channel_group_flags_changed_cb %r %r' %
+            (added, removed))
         self.text_channel_group_flags |= added
         self.text_channel_group_flags &= ~removed
 


### PR DESCRIPTION
Required by https://github.com/sugarlabs/sugar/pull/491

## Add ability to launch a bundle

This commit adds the `launch_bundle` function in `sugar3.activity.
activity` which accesses the same function in the shell is over dbus.
This is means the shell process launches the bundle.  Activities
should not launch child processes as per the Rainbow security model
[1].

[1]  http://wiki.laptop.org/go/Rainbow