### PR TITLE
Add ability to launch a bundle

### DIFF
--- a/src/sugar3/activity/activity.py
+++ b/src/sugar3/activity/activity.py
@@ -1091,3 +1091,10 @@ def show_object_in_journal(object_id):
     obj = bus.get_object(J_DBUS_SERVICE, J_DBUS_PATH)
     journal = dbus.Interface(obj, J_DBUS_INTERFACE)
     journal.ShowObject(object_id)
+
+
+def launch_bundle(bundle_id='', object_id=''):
+    bus = dbus.SessionBus()
+    obj = bus.get_object(J_DBUS_SERVICE, J_DBUS_PATH)
+    bundle_launcher = dbus.Interface(obj, J_DBUS_INTERFACE)
+    return bundle_launcher.LaunchBundle(bundle_id, object_id)


### PR DESCRIPTION
Replaces #210 

This commit adds the `launch_bundle` function in `sugar3.activity.
activity` which accesses the same function in the shell is over dbus.
This is means the shell process launches the bundle.  Activities
should not launch child processes as per the Rainbow security model
[1].

[1]  http://wiki.laptop.org/go/Rainbow