### PR TITLE
2015 05 silence power

### DIFF
--- a/src/sugar3/power.py
+++ b/src/sugar3/power.py
@@ -80,6 +80,5 @@ class PowerManager():
         try:
             os.unlink(self._path)
         except OSError:
-            logging.error("Inhibit Suspend: Could not delete file %s",
-                          self._path)
+            pass
         self._suspend_inhibit_counter = 0

--- a/src/sugar3/power.py
+++ b/src/sugar3/power.py
@@ -38,6 +38,7 @@ class PowerManager():
 
     def __init__(self):
         self._suspend_inhibit_counter = 0
+        self._path = os.path.join(_POWERD_INHIBIT_DIR, str(os.getpid()))
 
     def __del__(self):
         self._remove_flag_file()
@@ -50,13 +51,12 @@ class PowerManager():
             return
 
         if self._suspend_inhibit_counter == 0:
-            path = os.path.join(_POWERD_INHIBIT_DIR, str(os.getpid()))
             try:
-                with open(path, 'w') as flag_file:
+                with open(self._path, 'w') as flag_file:
                     flag_file.write('')
             except IOError:
                 logging.error("Inhibit Suspend: Could not create file %s",
-                              path)
+                              self._path)
 
         self._suspend_inhibit_counter += 1
 
@@ -77,9 +77,9 @@ class PowerManager():
         self._remove_flag_file()
 
     def _remove_flag_file(self):
-        path = os.path.join(_POWERD_INHIBIT_DIR, str(os.getpid()))
         try:
-            os.unlink(path)
+            os.unlink(self._path)
         except OSError:
-            logging.error("Inhibit Suspend: Could not delete file %s", path)
+            logging.error("Inhibit Suspend: Could not delete file %s",
+                          self._path)
         self._suspend_inhibit_counter = 0

--- a/src/sugar3/power.py
+++ b/src/sugar3/power.py
@@ -38,7 +38,10 @@ class PowerManager():
 
     def __init__(self):
         self._suspend_inhibit_counter = 0
-        self._path = os.path.join(_POWERD_INHIBIT_DIR, str(os.getpid()))
+        if os.path.exists(_POWERD_INHIBIT_DIR):
+            self._path = os.path.join(_POWERD_INHIBIT_DIR, str(os.getpid()))
+        else:
+            self._path = None
 
     def __del__(self):
         self._remove_flag_file()
@@ -47,10 +50,7 @@ class PowerManager():
         return True
 
     def inhibit_suspend(self):
-        if not os.path.exists(_POWERD_INHIBIT_DIR):
-            return
-
-        if self._suspend_inhibit_counter == 0:
+        if self._path and self._suspend_inhibit_counter == 0:
             try:
                 with open(self._path, 'w') as flag_file:
                     flag_file.write('')
@@ -77,8 +77,9 @@ class PowerManager():
         self._remove_flag_file()
 
     def _remove_flag_file(self):
-        try:
-            os.unlink(self._path)
-        except OSError:
-            pass
+        if self._path:
+            try:
+                os.unlink(self._path)
+            except OSError:
+                pass
         self._suspend_inhibit_counter = 0


### PR DESCRIPTION
Silence some errors associated with the power manager, and remove unnecessary filesystem accesses.

Tested on XO-1 and commodity hardware with Sugar 0.104 and Clock-17.