### PR TITLE
Add disable-update-mimedb option to bundlebuilder

### DIFF
--- a/src/sugar3/activity/bundlebuilder.py
+++ b/src/sugar3/activity/bundlebuilder.py
@@ -253,7 +253,7 @@ class Installer(Packager):
         Packager.__init__(self, builder.config)
         self.builder = builder
 
-    def install(self, prefix):
+    def install(self, prefix, update_mimedb=True):
         self.builder.build()
 
         activity_path = os.path.join(prefix, 'share', 'sugar', 'activities',
@@ -285,7 +285,8 @@ class Installer(Packager):
 
             shutil.copy(source, dest)
 
-        self.config.bundle.install_mime_type(self.config.source_dir)
+        if update_mimedb is True:
+            self.config.bundle.install_mime_type(self.config.source_dir)
 
 
 def cmd_check(config, options):
@@ -373,7 +374,7 @@ def cmd_install(config, options):
     """Install the activity in the system"""
 
     installer = Installer(Builder(config))
-    installer.install(options.prefix)
+    installer.install(options.prefix, options.update_mimedb)
 
 
 def cmd_genpot(config, options):
@@ -437,6 +438,10 @@ def start():
     install_parser.add_argument(
         "--prefix", dest="prefix", default=sys.prefix,
         help="Path for installing")
+    install_parser.add_argument(
+        "--disable-update-mimedb", dest="update_mimedb",
+        action="store_false", default=True,
+        help="Skip mime types installation in the system")
 
     check_parser = subparsers.add_parser(
         "check", help="Run tests for the activity")


### PR DESCRIPTION
Historically, distro packagers have been using bunblebuilder, via
"setup.py install", to populate packages directories and files.

The install procedure uses ActivityBundle.install_mime_type to install
custom mime types, by creating symlinks and updating the system mime
types database via the update-mime-database tool.

When ActivityBundle.install_mime_type is executed during packages
creation, the symlinks end-up broken in the final package and the use
of update-mime-database populates the final packages with a new copy
of the database files which could clash with the system copy.

This patch adds a new option, called --disable-update-mimedb to setup.py
install to skip the execution of ActivityBundle.install_mime_type and
avoid the issues mentioned above.

Activity packagers should use this new option. The creation of symlinks
and the execution of update-mime-database should be done in post install
packaging steps.

To test in sugar-build:

1. Make sure there is no mime database generated
```
$ cd sugar-build/home/default/data;
$ rm -rf mime;
```

2. Using the shell install an activity with and without the --disable-update-mimedb option.
```
$ ./osbuild shell
$ cd ./read
$ ./setup.py install # and,
$ ./setup.py install --disable-update-mimedb 
```

Signed-off-by: Martin Abente Lahaye <tch@sugarlabs.org>