### PR TITLE
sugar-activity-web: remove bash specific code

### DIFF
--- a/bin/sugar-activity-web
+++ b/bin/sugar-activity-web
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-if [ "$SUGAR_USE_WEBKIT1" == "yes" ]; then
+if [ "$SUGAR_USE_WEBKIT1" = "yes" ]; then
     exec sugar-activity sugar3.activity.webkit1.WebActivity $@
 else
     exec sugar-activity sugar3.activity.webactivity.WebActivity $@


### PR DESCRIPTION
Gears activity on Ubuntu with Sugar 0.105.1 shows this in logs:

```
/usr/bin/sugar-activity-web: 20: [: unexpected operator
```

Cause is bash-specific coding in script.