### PR TITLE
Secondary text on palettes should respect the max width - Fixes #4862

### DIFF
--- a/src/sugar3/graphics/palette.py
+++ b/src/sugar3/graphics/palette.py
@@ -286,6 +286,7 @@ class Palette(PaletteWindow):
                 self._secondary_label.set_line_wrap(True)
                 self._secondary_label.set_ellipsize(
                     style.ELLIPSIZE_MODE_DEFAULT)
+                self._secondary_label.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
                 self._secondary_label.set_lines(NO_OF_LINES)
                 self._secondary_label.set_justify(Gtk.Justification.FILL)
             else:


### PR DESCRIPTION
When a activity have a title very long without spaces,
the text can't be wraped with the default wrap mode (WORD)
Use WRAP_CHAR to solve this issue.