### PR TITLE
translations: add Guarani to LINGUAS

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -32,6 +32,7 @@ fi
 fil
 fr
 gl
+gn
 gu
 ha
 he


### PR DESCRIPTION
A group of kids from the OLPC project in Caacupe have translated both
the sugar shell and the sugar gtk3 toolkit to Guarani. They are also in
the process of translating sugar activities [1].

This patch add the gn entry to the LINGUAS file so the gn.po file can be
properly installed, as already is being done with the sugar shell.

[1] http://translate.sugarlabs.org/gn/

Signed-off-by: Martin Abente Lahaye <tch@sugarlabs.org>