### PR TITLE
Fix set_wrap_mode does not exsist error

### DIFF
--- a/src/sugar3/graphics/palette.py
+++ b/src/sugar3/graphics/palette.py
@@ -286,7 +286,7 @@ class Palette(PaletteWindow):
                 self._secondary_label.set_line_wrap(True)
                 self._secondary_label.set_ellipsize(
                     style.ELLIPSIZE_MODE_DEFAULT)
-                self._secondary_label.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+                self._secondary_label.props.wrap_mode = Gtk.WrapMode.WORD_CHAR
                 self._secondary_label.set_lines(NO_OF_LINES)
                 self._secondary_label.set_justify(Gtk.Justification.FILL)
             else:


### PR DESCRIPTION
Commit 034706a introduced an error on Fedora rawhide (23):

    Traceback (most recent call last):
      File "/usr/lib64/python2.7/site-packages/gi/_propertyhelper.py", line 427, in obj_set_property
        prop.fset(self, value)
      File "/home/sam/sb21/build/out/install/lib/python2.7/site-packages/sugar3/graphics/palette.py", line 289, in set_secondary_text
        self._secondary_label.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
    AttributeError: 'Label' object has no attribute 'set_wrap_mode'