### PR TITLE
Replace use of deprecated icon_size by pixel_size

### DIFF
--- a/src/sugar3/graphics/menuitem.py
+++ b/src/sugar3/graphics/menuitem.py
@@ -47,14 +47,14 @@ class MenuItem(Gtk.ImageMenuItem):
 
         if icon_name is not None:
             icon = Icon(icon_name=icon_name,
-                        icon_size=Gtk.IconSize.SMALL_TOOLBAR)
+                        pixel_size=style.SMALL_ICON_SIZE)
             if xo_color is not None:
                 icon.props.xo_color = xo_color
             self.set_image(icon)
             icon.show()
 
         elif file_name is not None:
-            icon = Icon(file=file_name, icon_size=Gtk.IconSize.SMALL_TOOLBAR)
+            icon = Icon(file=file_name, pixel_size=style.SMALL_ICON_SIZE)
             if xo_color is not None:
                 icon.props.xo_color = xo_color
             self.set_image(icon)

--- a/src/sugar3/graphics/palette.py
+++ b/src/sugar3/graphics/palette.py
@@ -336,7 +336,7 @@ class Palette(PaletteWindow):
             event_box.show()
 
             self._icon = icon
-            self._icon.props.icon_size = Gtk.IconSize.LARGE_TOOLBAR
+            self._icon.props.pixel_size = style.STANDARD_ICON_SIZE
             event_box.add(self._icon)
             self._icon.show()
             self._show_icon()

--- a/src/sugar3/graphics/palettemenu.py
+++ b/src/sugar3/graphics/palettemenu.py
@@ -121,14 +121,14 @@ class PaletteMenuItem(Gtk.EventBox):
 
         if icon_name is not None:
             self.icon = Icon(icon_name=icon_name,
-                             icon_size=Gtk.IconSize.SMALL_TOOLBAR)
+                             pixel_size=style.SMALL_ICON_SIZE)
             if xo_color is not None:
                 self.icon.props.xo_color = xo_color
             self._hbox.pack_start(self.icon, expand=False, fill=False,
                                   padding=style.DEFAULT_PADDING)
         elif file_name is not None:
             self.icon = Icon(file=file_name,
-                             icon_size=Gtk.IconSize.SMALL_TOOLBAR)
+                             pixel_size=style.SMALL_ICON_SIZE)
             if xo_color is not None:
                 self.icon.props.xo_color = xo_color
             self._hbox.pack_start(self.icon, expand=False, fill=False,

--- a/src/sugar3/graphics/tray.py
+++ b/src/sugar3/graphics/tray.py
@@ -188,7 +188,7 @@ class _TrayScrollButton(ToolButton):
         self.set_size_request(style.GRID_CELL_SIZE, style.GRID_CELL_SIZE)
 
         self.icon = Icon(icon_name=icon_name,
-                         icon_size=Gtk.IconSize.SMALL_TOOLBAR)
+                         pixel_size=style.SMALL_ICON_SIZE)
         # The alignment is a hack to work around Gtk.ToolButton code
         # that sets the icon_size when the icon_widget is a Gtk.Image
         alignment = Gtk.Alignment(xalign=0.5, yalign=0.5)
@@ -435,7 +435,7 @@ class _IconWidget(Gtk.EventBox):
                         Gdk.EventMask.BUTTON_RELEASE_MASK)
 
         self._icon = Icon(icon_name=icon_name, xo_color=xo_color,
-                          icon_size=Gtk.IconSize.LARGE_TOOLBAR)
+                          pixel_size=style.STANDARD_ICON_SIZE)
         self.add(self._icon)
         self._icon.show()
 

--- a/src/sugar3/graphics/window.py
+++ b/src/sugar3/graphics/window.py
@@ -28,6 +28,7 @@ from gi.repository import Gtk
 
 from sugar3.graphics.icon import Icon
 from sugar3.graphics import palettegroup
+from sugar3.graphics import style
 
 
 _UNFULLSCREEN_BUTTON_VISIBILITY_TIMEOUT = 2
@@ -58,7 +59,7 @@ class UnfullscreenButton(Gtk.Window):
         self._button.set_relief(Gtk.ReliefStyle.NONE)
 
         self._icon = Icon(icon_name='view-return',
-                          icon_size=Gtk.IconSize.LARGE_TOOLBAR)
+                          pixel_size=style.STANDARD_ICON_SIZE)
         self._icon.show()
         self._button.add(self._icon)
 


### PR DESCRIPTION
It's a trivial change, but the warning message was filling the logs.