### PR TITLE
Add get_bundle method to activity.py

### DIFF
--- a/src/sugar3/activity/activity.py
+++ b/src/sugar3/activity/activity.py
@@ -83,6 +83,7 @@ from sugar3.graphics.alert import Alert
 from sugar3.graphics.icon import Icon
 from sugar3.datastore import datastore
 from sugar3.bundle.activitybundle import get_bundle_instance
+from sugar3.bundle.helpers import bundle_from_dir
 from gi.repository import SugarExt
 
 _ = lambda msg: gettext.dgettext('sugar-toolkit-gtk3', msg)
@@ -1166,3 +1167,14 @@ def launch_bundle(bundle_id='', object_id=''):
     obj = bus.get_object(J_DBUS_SERVICE, J_DBUS_PATH)
     bundle_launcher = dbus.Interface(obj, J_DBUS_INTERFACE)
     return bundle_launcher.LaunchBundle(bundle_id, object_id)
+
+
+def get_bundle(bundle_id='', object_id=''):
+    bus = dbus.SessionBus()
+    obj = bus.get_object(J_DBUS_SERVICE, J_DBUS_PATH)
+    journal = dbus.Interface(obj, J_DBUS_INTERFACE)
+    bundle_path = journal.GetBundlePath(bundle_id, object_id)
+    if bundle_path:
+        return bundle_from_dir(bundle_path)
+    else:
+        return None


### PR DESCRIPTION
When a programmer need open one activity from other [1]
usually need display in the user interface information about the activity
to open, like the name or the icon.
This method allow get this information, previously only available on jarabe.

[1] http://wiki.sugarlabs.org/go/Features/Start_activity_from_another_activity