### PR TITLE
Don't add a label on RadioToolButton when set icon_widget - Fixes #4875

### DIFF
--- a/src/sugar3/graphics/radiotoolbutton.py
+++ b/src/sugar3/graphics/radiotoolbutton.py
@@ -48,6 +48,11 @@ class RadioToolButton(Gtk.RadioToolButton):
         if icon_name:
             self.set_icon_name(icon_name)
 
+        # HACK: stop Gtk from adding a label and expanding the size of
+        # the button. This happen when set_icon_widget is called
+        # if label_widget is None
+        self.props.label_widget = Gtk.Box()
+
         self.connect('destroy', self.__destroy_cb)
 
     def __destroy_cb(self, icon):


### PR DESCRIPTION
When we use set_icon_widget(), GtkToolButton set a private property
contents_invalid = TRUE [1], and gtk_tool_button_construct_content [2]
is called. Then if the label widget not exist, a GtkLabel is added.
This is a problem for us, by example in the Clipboard buttons in the frame.
By adding a empty Gtk.Box instead of a label, we avoid the label creation.

But as this is a internal implementation of Gtk, can change in the future,
in fact the issue is not visible with Gtk < 3.16

This patch is based in a pr sent by Sam Parkinson

[1] https://github.com/GNOME/gtk/blob/master/gtk/gtktoolbutton.c#L1415
[2] https://github.com/GNOME/gtk/blob/master/gtk/gtktoolbutton.c#L357