### PR TITLE
Only activate menu items if the mouse releases in them - fixes #4863

### DIFF
--- a/src/sugar3/graphics/palettemenu.py
+++ b/src/sugar3/graphics/palettemenu.py
@@ -159,7 +159,9 @@ class PaletteMenuItem(Gtk.EventBox):
         self.show_all()
 
     def __button_release_cb(self, widget, event):
-        self.emit('activate')
+        alloc = self.get_allocation()
+        if 0 < event.x < alloc.width and 0 < event.y < alloc.height:
+            self.emit('activate')
 
     def __enter_notify_cb(self, widget, event):
         self.modify_bg(Gtk.StateType.NORMAL,


### PR DESCRIPTION
Ticket URL <http://bugs.sugarlabs.org/ticket/4863>

@Quozl wrote a very good ticket which serves as a good description:

The industry convention for mouse driven menu options is for them to be activated when two conditions are met:

* a button down event occurs with the pointer inside the option, and;
* a button up event occurs with the pointer inside the option. 

The latter condition is not being checked in the Sugar menus.

Reproducer: right-click on the buddy menu, put the pointer over the My Settings option, press down on the button, move the pointer out of the menu, release the button.

Expected result: menu is dismissed.

Observed result: menu is dismissed, and the My Settings option is activated.