### PR TITLE
Check icon release pos

### DIFF
--- a/src/sugar3/graphics/icon.py
+++ b/src/sugar3/graphics/icon.py
@@ -557,6 +557,10 @@ class EventIcon(Gtk.EventBox):
     cursor-positioned palette invoker.
     """
 
+    __gsignals__ = {
+        'activate': (GObject.SignalFlags.RUN_FIRST, None, []),
+    }
+
     __gtype_name__ = 'SugarEventIcon'
 
     def __init__(self, **kwargs):
@@ -569,6 +573,7 @@ class EventIcon(Gtk.EventBox):
         self.add_events(Gdk.EventMask.BUTTON_PRESS_MASK |
                         Gdk.EventMask.TOUCH_MASK |
                         Gdk.EventMask.BUTTON_RELEASE_MASK)
+        self.connect('button-release-event', self.__button_release_event_cb)
         for key, value in kwargs.iteritems():
             self.set_property(key, value)
 
@@ -755,6 +760,11 @@ class EventIcon(Gtk.EventBox):
         from sugar3.graphics.palette import Palette
 
         self.set_palette(Palette(text))
+
+    def __button_release_event_cb(self, icon, event):
+        alloc = self.get_allocation()
+        if 0 < event.x < alloc.width and 0 < event.y < alloc.height:
+            self.emit('activate')
 
 
 class CanvasIcon(EventIcon):

--- a/src/sugar3/graphics/palettewindow.py
+++ b/src/sugar3/graphics/palettewindow.py
@@ -1334,6 +1334,11 @@ class CursorInvoker(Invoker):
         return False
 
     def __button_release_event_cb(self, button, event):
+        # check if the release is done outside of the parent widget
+        alloc = self._item.get_allocation()
+        if not (0 < event.x < alloc.width and 0 < event.y < alloc.height):
+            return False
+
         if self._long_pressed_recognized:
             self._long_pressed_recognized = False
             return True


### PR DESCRIPTION
These patches complement the fix of bug http://bugs.sugarlabs.org/ticket/4863 taking care of the events on the EventIcons and their palettes.
A new event 'activate' is added for consistency with PaletteMenuItem.
Changes in Sugar are needed to use this event, but do not brek compatibility.