### PR TITLE
MouseDetector timeout_id need reset

### DIFF
--- a/src/sugar3/graphics/palettewindow.py
+++ b/src/sugar3/graphics/palettewindow.py
@@ -441,6 +441,7 @@ class MouseSpeedDetector(GObject.GObject):
     def stop(self):
         if self._timeout_hid is not None:
             GObject.source_remove(self._timeout_hid)
+            self._timeout_hid = None
         self._state = None
 
     def _get_mouse_position(self):


### PR DESCRIPTION
The mouse detector have a variable to store the id for the timeout.
The stop() method check if the id is null but do not set the id to null
after remove the GObject timeout, then try to remove the timeout multiple times.

The efect can be seen if a user move the mouse slowly over the icons
in the Sugar home, in shell.log we see many lines like:

sugar3/graphics/palettewindow.py:443: Warning: Source ID 2464 was not found
when attempting to remove it