### PR TITLE
Check if parameter 'options' is None in cmd_dist_xo

### DIFF
--- a/src/sugar3/activity/bundlebuilder.py
+++ b/src/sugar3/activity/bundlebuilder.py
@@ -350,8 +350,11 @@ def cmd_dev(config, options):
 
 def cmd_dist_xo(config, options):
     """Create a xo bundle package"""
+    no_fail = False
+    if options is not None:
+        no_fail = options.no_fail
 
-    packager = XOPackager(Builder(config, options.no_fail))
+    packager = XOPackager(Builder(config, no_fail))
     packager.package()
 
 


### PR DESCRIPTION
When is used to clone a activity from sugar,
the options parameter is set to None.
The other uses of no_fail have False as default value
but this case was missing.
The effect of this error is that a .xo is not created in the Journal,
when the user select 'Duplicate' in the View Source window.