### PR TITLE
EventIcon: only trigger 'activate' signal on principal button click

### DIFF
--- a/src/sugar3/graphics/icon.py
+++ b/src/sugar3/graphics/icon.py
@@ -762,9 +762,10 @@ class EventIcon(Gtk.EventBox):
         self.set_palette(Palette(text))
 
     def __button_release_event_cb(self, icon, event):
-        alloc = self.get_allocation()
-        if 0 < event.x < alloc.width and 0 < event.y < alloc.height:
-            self.emit('activate')
+        if event.button == 1:
+            alloc = self.get_allocation()
+            if 0 < event.x < alloc.width and 0 < event.y < alloc.height:
+                self.emit('activate')
 
 
 class CanvasIcon(EventIcon):


### PR DESCRIPTION
With the introduction of 'activate' signal on [1], and the use of that
signal in Sugar Home, we introduced a bug, now, pressing the secondary button
starts the activity instead of open the palette.
This patch solves the issue checking the putton pressed before send the signal.

[1] a19cf9ed2787f9db492fcac4505d5bc52dbaf3a0