### PR TITLE
Do not calculate palette height on PaletteWindowWidget - Fixes #4792

### DIFF
--- a/src/sugar3/graphics/palettewindow.py
+++ b/src/sugar3/graphics/palettewindow.py
@@ -621,18 +621,19 @@ class PaletteWindow(GObject.GObject):
             return
 
         req = self._widget.size_request()
-        # on Gtk 3.10, menu at the bottom of the screen are resized
-        # to not fall out, and report a wrong size.
-        # measure the children and move the menu - SL #4673
-        total_height = 0
-        for child in self._widget.get_children():
-            child_req = child.size_request()
-            total_height += child_req.height
+        if isinstance(self._widget, _PaletteMenuWidget):
+            # on Gtk 3.10, menu at the bottom of the screen are resized
+            # to not fall out, and report a wrong size.
+            # measure the children and move the menu - SL #4673
+            total_height = 0
+            for child in self._widget.get_children():
+                child_req = child.size_request()
+                total_height += child_req.height
 
-        # need add the border line width as defined in sugar-artwork
-        line_width = 2
-        total_height += line_width * 2
-        req.height = total_height
+            # need add the border line width as defined in sugar-artwork
+            line_width = 2
+            total_height += line_width * 2
+            req.height = total_height
 
         position = invoker.get_position_for_alignment(self._alignment, req)
         if position is None:


### PR DESCRIPTION
To solve ticket #4673, we calculate the palette size using the size
of all the widgets [2]. That solves the problem on Palettes based on
_PaletteMenuWidget but on _PaletteWindowWidget produce a wrong value
when the secondary_label is not null, and as a consequence
the palette position is wrong.
The solution is do the calculation only for _PaletteMenuWidget based
palettes.

[1] https://bugs.sugarlabs.org/ticket/4673
[2] b9d6b628a98fc17f5e92a344450b6336f1a2b2ce