### PR TITLE
Allow import datstore.py without glib loop

### DIFF
--- a/src/sugar3/datastore/datastore.py
+++ b/src/sugar3/datastore/datastore.py
@@ -48,9 +48,12 @@ def _get_data_store():
         _data_store = dbus.Interface(_bus.get_object(DS_DBUS_SERVICE,
                                                      DS_DBUS_PATH),
                                      DS_DBUS_INTERFACE)
-        _data_store.connect_to_signal('Created', __datastore_created_cb)
-        _data_store.connect_to_signal('Deleted', __datastore_deleted_cb)
-        _data_store.connect_to_signal('Updated', __datastore_updated_cb)
+        try:
+            _data_store.connect_to_signal('Created', __datastore_created_cb)
+            _data_store.connect_to_signal('Deleted', __datastore_deleted_cb)
+            _data_store.connect_to_signal('Updated', __datastore_updated_cb)
+        except RuntimeError:
+            logging.error('Error trying to connect to datastore')
 
     return _data_store
 


### PR DESCRIPTION
Right now is not possible do "from sugar3.datastore import datastore"
outside of GLib loop, because the import try to connect to a DBus signal,
and throw a exception.

That was not a problem in Sugar, because we always have a Glib loop
on all our activities, but is a problem when we want import the classes
to generate docs with pydoc. Many other classes import datastore,
then this is a blocker.

This patch add a try catch to allow this use case.