### PR TITLE
Init the datastore on demand

### DIFF
--- a/src/sugar3/datastore/datastore.py
+++ b/src/sugar3/datastore/datastore.py
@@ -72,8 +72,6 @@ created = dispatch.Signal()
 deleted = dispatch.Signal()
 updated = dispatch.Signal()
 
-_get_data_store()
-
 
 class DSMetadata(GObject.GObject):
     """A representation of the metadata associated with a DS entry."""


### PR DESCRIPTION
Right now is not possible do "from sugar3.datastore import datastore"
outside of GLib loop, because the import try to connect to a DBus signal,
and throw a exception.

That was not a problem in Sugar, because we always have a Glib loop
on all our activities, but is a problem when we want import the classes
to generate docs with pydoc. Many other classes import datastore,
then this is a blocker.

This patch removes the initialization when imported,
will be done when needed.