### PR TITLE
make NotifyAlert inherit from TimeoutAlert

### DIFF
--- a/src/sugar3/graphics/alert.py
+++ b/src/sugar3/graphics/alert.py
@@ -413,7 +413,7 @@ class TimeoutAlert(Alert):
         return True
 
 
-class NotifyAlert(Alert):
+class NotifyAlert(TimeoutAlert):
     """
     Timeout alert with only an "OK" button.  This should be used just for
     notifications and not for user interaction.  The alert will timeout after
@@ -455,10 +455,3 @@ class NotifyAlert(Alert):
 
         GLib.timeout_add(1000, self.__timeout)
 
-    def __timeout(self):
-        self._timeout -= 1
-        self._timeout_text.set_text(self._timeout)
-        if self._timeout == 0:
-            self._response(Gtk.ResponseType.OK)
-            return False
-        return True


### PR DESCRIPTION
Only difference between a ```NotifyAlert``` and a ```TimeoutAlert``` is in the ```__init__```, in particular the ```__timeout``` method is identical to that in ```TimeoutAlert```.