### PR TITLE
Specify library version prior to import, fixes #4900

### DIFF
--- a/src/sugar3/graphics/icon.py
+++ b/src/sugar3/graphics/icon.py
@@ -27,6 +27,8 @@ import logging
 import os
 from ConfigParser import ConfigParser
 
+import gi
+gi.require_version('Rsvg', '2.0')
 from gi.repository import GObject
 from gi.repository import Gtk
 from gi.repository import Gdk

--- a/src/sugar3/test/uitree.py
+++ b/src/sugar3/test/uitree.py
@@ -21,6 +21,8 @@ UNSTABLE.
 import logging
 import time
 
+import gi
+gi.require_version('Atspi', '2.0')
 from gi.repository import Atspi
 from gi.repository import GLib
 


### PR DESCRIPTION
Gi has been emitting warnings into the log to do this for some
time now. Not doing this has also caused bugs, such as #4900.

Also see https://github.com/sugarlabs/sugar/pull/600