### PR TITLE
allow start on full disk

### DIFF
--- a/src/sugar3/logger.py
+++ b/src/sugar3/logger.py
@@ -105,16 +105,21 @@ def cleanup():
                 os.remove(os.path.join(root, f))
             os.rmdir(root)
         except OSError, e:
-            print "Could not remove old logs filesi %s" % e
+            print "Could not remove old logs files %s" % e
 
     if len(backup_logs) > 0:
         name = str(int(time.time()))
         backup_dir = os.path.join(logs_dir, name)
-        os.mkdir(backup_dir)
-        for log in backup_logs:
-            source_path = os.path.join(logs_dir, log)
-            dest_path = os.path.join(backup_dir, log)
-            os.rename(source_path, dest_path)
+        try:
+            os.mkdir(backup_dir)
+            for log in backup_logs:
+                source_path = os.path.join(logs_dir, log)
+                dest_path = os.path.join(backup_dir, log)
+                os.rename(source_path, dest_path)
+        except OSError, e:
+            # gracefully deal w/ disk full
+            if e.errno != errno.ENOSPC:
+                raise e
 
 
 def start(log_filename=None):


### PR DESCRIPTION
When disk is full, Sugar will not start, because the backup log directory cannot be created.

X session logs in tmpfs show this exception:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/usr/lib/python2.7/site-packages/jarabe/main.py", line 20, in <module>
    logger.cleanup()
  File "/usr/lib/python2.7/site-packages/sugar3/logger.py", line 113, in cleanup
    os.mkdir(backup_dir)
OSError: [Errno 28] No space left on device:
    '/home/user/.sugar/default/logs/1448258018'
```

Fix is to ignore the exception.

We've been here before!  Was previously fixed in 2010:

 - https://github.com/sugarlabs/sugar/commit/4cde481
 - https://bugs.sugarlabs.org/ticket/1720
 - http://dev.laptop.org/ticket/9623

But new regression introduced in 2012 during reorganisation of code by Daniel Narvaez; the exception was no longer handled:

 - https://github.com/sugarlabs/sugar/commit/0e45f9d
 - https://github.com/sugarlabs/sugar/commit/19db9c5

Reported-by: Nathan Riddle <nathanr333@charter.net>
Tested-by: James Cameron <quozl@laptop.org>