### PR TITLE
demote warning to debug for sugar_accel_group

### DIFF
--- a/src/sugar3/graphics/colorbutton.py
+++ b/src/sugar3/graphics/colorbutton.py
@@ -402,7 +402,7 @@ def _add_accelerator(tool_button):
     # TODO: should we remove the accelerator from the prev top level?
 
     if not hasattr(tool_button.get_toplevel(), 'sugar_accel_group'):
-        logging.warning('No Gtk.AccelGroup in the top level window.')
+        logging.debug('No Gtk.AccelGroup in the top level window.')
         return
 
     accel_group = tool_button.get_toplevel().sugar_accel_group

--- a/src/sugar3/graphics/menuitem.py
+++ b/src/sugar3/graphics/menuitem.py
@@ -77,7 +77,7 @@ class MenuItem(Gtk.ImageMenuItem):
         # TODO: should we remove the accelerator from the prev top level?
 
         if not hasattr(self.get_toplevel(), 'sugar_accel_group'):
-            logging.warning('No Gtk.AccelGroup in the top level window.')
+            logging.debug('No Gtk.AccelGroup in the top level window.')
             return
 
         accel_group = self.get_toplevel().sugar_accel_group

--- a/src/sugar3/graphics/toggletoolbutton.py
+++ b/src/sugar3/graphics/toggletoolbutton.py
@@ -36,7 +36,7 @@ def _add_accelerator(tool_button):
 
     # TODO: should we remove the accelerator from the prev top level?
     if not hasattr(tool_button.get_toplevel(), 'sugar_accel_group'):
-        logging.warning('No Gtk.AccelGroup in the top level window.')
+        logging.debug('No Gtk.AccelGroup in the top level window.')
         return
 
     accel_group = tool_button.get_toplevel().sugar_accel_group

--- a/src/sugar3/graphics/toolbutton.py
+++ b/src/sugar3/graphics/toolbutton.py
@@ -36,7 +36,7 @@ def _add_accelerator(tool_button):
 
     # TODO: should we remove the accelerator from the prev top level?
     if not hasattr(tool_button.get_toplevel(), 'sugar_accel_group'):
-        logging.warning('No Gtk.AccelGroup in the top level window.')
+        logging.debug('No Gtk.AccelGroup in the top level window.')
         return
 
     accel_group = tool_button.get_toplevel().sugar_accel_group


### PR DESCRIPTION
This warning is frequently seen in logs but is not that important to warrant being a warning.