### PR TITLE
Fix remaining icon_size references

### DIFF
--- a/src/sugar3/graphics/colorbutton.py
+++ b/src/sugar3/graphics/colorbutton.py
@@ -59,7 +59,7 @@ class _ColorButton(Gtk.Button):
         self._accept_drag = True
 
         self._preview = Icon(icon_name='color-preview',
-                             icon_size=Gtk.IconSize.BUTTON)
+                             pixel_size=Gtk.IconSize.BUTTON)
 
         GObject.GObject.__init__(self, **kwargs)
 


### PR DESCRIPTION
icon_size was changed to pixel_size, yet references remained, causing
extra log data.