### PR TITLE
Fix remaining icon_size references

### DIFF
--- a/src/sugar3/graphics/colorbutton.py
+++ b/src/sugar3/graphics/colorbutton.py
@@ -59,7 +59,7 @@ class _ColorButton(Gtk.Button):
         self._accept_drag = True
 
         self._preview = Icon(icon_name='color-preview',
-                             pixel_size=Gtk.IconSize.BUTTON)
+                             pixel_size=style.SMALL_ICON_SIZE)
 
         GObject.GObject.__init__(self, **kwargs)
 


### PR DESCRIPTION
icon_size was changed to pixel_size, yet references remained, causing extra log data.

Additional change missed from already merged 70bc4db, #276.  Later #277 revert was not merged, so this patch can be merged now.

Tested on Ubuntu 15.10 with Sugar 0.107 and Paint-65, which has references to colorbutton.