### PR TITLE
Set value of "ph" to 0 if division by zero takes place

### DIFF
--- a/src/sugar3/graphics/palettewindow.py
+++ b/src/sugar3/graphics/palettewindow.py
@@ -970,15 +970,19 @@ class Invoker(GObject.GObject):
             dright = screen_area.x + screen_area.width - rect.x - rect.width
 
             ih = 0
+            
+            if palette_dim.width == 0:
+                ph = 0
 
-            # Set palette_halign to align to screen on left
-            if dleft > dright:
-                ph = -float(dleft) / palette_dim.width
-
-            # Set palette_halign to align to screen on right
             else:
-                ph = -float(palette_dim.width - dright - rect.width) \
-                    / palette_dim.width
+                # Set palette_halign to align to screen on left
+                if dleft > dright:
+                    ph = -float(dleft) / palette_dim.width
+
+                # Set palette_halign to align to screen on right
+                else:
+                    ph = -float(palette_dim.width - dright - rect.width) \
+                        / palette_dim.width
 
         return (ph, pv, ih, iv)
 


### PR DESCRIPTION
The log is always filled with many of these errors where division by zero takes place especially when I drag objects from the clipboard to other places.

This is happening since the palette_dim.width is becoming 0 at times, so its rising the division by zero error.