### PR TITLE
Set css name for widgets

### DIFF
--- a/src/sugar3/graphics/alert.py
+++ b/src/sugar3/graphics/alert.py
@@ -209,6 +209,8 @@ class Alert(Gtk.EventBox):
 
     def __button_clicked_cb(self, button, response_id):
         self._response(response_id)
+if hasattr(Alert, 'set_css_name'):
+    Alert.set_css_name('alert')
 
 
 class ConfirmationAlert(Alert):
@@ -344,6 +346,8 @@ class _TimeoutIcon(Gtk.Alignment):
 
     def set_text(self, text):
         self._text.set_markup('<b>%s</b>' % GLib.markup_escape_text(str(text)))
+if hasattr(_TimeoutIcon, 'set_css_name'):
+    _TimeoutIcon.set_css_name('timeouticon')
 
 
 class _TimeoutAlert(Alert):

--- a/src/sugar3/graphics/icon.py
+++ b/src/sugar3/graphics/icon.py
@@ -831,6 +831,8 @@ class CanvasIcon(EventIcon):
 
     def __palette_popdown_cb(self, palette):
         self.unset_state_flags(Gtk.StateFlags.PRELIGHT)
+if hasattr(CanvasIcon, 'set_css_name'):
+    CanvasIcon.set_css_name('canvasicon')
 
 
 class CellRendererIcon(Gtk.CellRenderer):

--- a/src/sugar3/graphics/palettewindow.py
+++ b/src/sugar3/graphics/palettewindow.py
@@ -1198,6 +1198,7 @@ class WidgetInvoker(Invoker):
 
         context = self.parent.get_style_context()
         context.add_class('toolitem')
+        context.add_class('palette-down')
 
         gap = _calculate_gap(self.get_rect(), palette.get_rect())
         if gap:

--- a/src/sugar3/graphics/palettewindow.py
+++ b/src/sugar3/graphics/palettewindow.py
@@ -363,7 +363,7 @@ class _PaletteWindowWidget(Gtk.Window):
 
         allocation = self.get_allocation()
         context = self.get_style_context()
-        context.add_class('toolitem')
+        context.add_class('palette')
         if gap:
             cr.save()
             cr.set_source_rgb(0, 0, 0)
@@ -406,6 +406,8 @@ class _PaletteWindowWidget(Gtk.Window):
         self.disconnect_by_func(self.__enter_notify_event_cb)
         self.disconnect_by_func(self.__leave_notify_event_cb)
         self.hide()
+if hasattr(_PaletteWindowWidget, 'set_css_name'):
+    _PaletteWindowWidget.set_css_name('palette')
 
 
 class MouseSpeedDetector(GObject.GObject):

--- a/src/sugar3/graphics/toolbarbox.py
+++ b/src/sugar3/graphics/toolbarbox.py
@@ -202,6 +202,8 @@ class ToolbarBox(Gtk.VBox):
         if button == self.expanded_button:
             self.remove(button.page_widget)
             self._expanded_button_index = -1
+if hasattr(ToolbarBox, 'set_css_name'):
+    ToolbarBox.set_css_name('toolbarbox')
 
 
 class _ToolbarPalette(PaletteWindow):

--- a/src/sugar3/graphics/toolbarbox.py
+++ b/src/sugar3/graphics/toolbarbox.py
@@ -130,6 +130,7 @@ class ToolbarButton(ToolButton):
         alloc = self.get_allocation()
         context = self.get_style_context()
         context.add_class('toolitem')
+        context.add_class('toolbar-down')
         if not self.is_expanded() or self.props.palette is not None and \
                 self.props.palette.is_up():
             ToolButton.do_draw(self, cr)

--- a/src/sugar3/graphics/tray.py
+++ b/src/sugar3/graphics/tray.py
@@ -323,6 +323,8 @@ class HTray(Gtk.EventBox):
 
     def scroll_to_item(self, item):
         self._viewport.scroll_to_item(item)
+if hasattr(HTray, 'set_css_name'):
+    HTray.set_css_name('htray')
 
 
 class VTray(Gtk.EventBox):
@@ -414,6 +416,8 @@ class VTray(Gtk.EventBox):
 
     def scroll_to_item(self, item):
         self._viewport.scroll_to_item(item)
+if hasattr(VTray, 'set_css_name'):
+    VTray.set_css_name('VTray')
 
 
 class TrayButton(ToolButton):


### PR DESCRIPTION
Required by https://github.com/sugarlabs/sugar-artwork/pull/86

In Gtk+ 3.20, you need to use the css name to select elements,
rather than the gtype name.  Therefore, these must be added.

The css name must be set before the class instances are created, as
it effects the class rather than the instance.  This is why it must
be places after the class definition.