### PR TITLE
Handle directories in bundle builder install, fixes git submodules

### DIFF
--- a/src/sugar3/activity/bundlebuilder.py
+++ b/src/sugar3/activity/bundlebuilder.py
@@ -283,7 +283,15 @@ class Installer(Packager):
             if not os.path.exists(path):
                 os.makedirs(path)
 
-            shutil.copy(source, dest)
+            if os.path.isfile(source):
+                shutil.copy(source, dest)
+            else:
+                if os.path.isdir(dest):
+                    # shutil can't copytree is dest exists
+                    shutil.rmtree(dest)
+                # Git may give us directories to copy, namely with git
+                # submodules they are only included as their root path
+                shutil.copytree(source, dest)
 
         if install_mime:
             self.config.bundle.install_mime_type(self.config.source_dir)


### PR DESCRIPTION
Currently, having a submodule in an activity crashes the install
script as git returns submodules as directories in git ls-files.
This commit means that submodules are reccursively coppied, as
they would be with "cp -r".

To reproduce the issue, you could do something like the following:

    cd pippy
    git clone https://github.com/samdroid-apps/collabwrapper
    git add collabwrapper
    python setup.py install  # or just osbuild run