### PR TITLE
Set sugar cursor internally in sugar

### DIFF
--- a/src/sugar3/activity/activity.py
+++ b/src/sugar3/activity/activity.py
@@ -385,6 +385,9 @@ class Activity(Window, Gtk.Container):
         self._bus = ActivityService(self)
         self._owns_file = False
 
+        sugar_cursor = Gdk.Cursor(Gdk.CursorType.LEFT_PTR)
+        self.get_window().set_cursor(sugar_cursor)
+
         share_scope = SCOPE_PRIVATE
 
         if handle.object_id:

--- a/src/sugar3/graphics/window.py
+++ b/src/sugar3/graphics/window.py
@@ -138,6 +138,9 @@ class Window(Gtk.Window):
         self.add(self.__vbox)
         self.__vbox.show()
 
+        sugar_cursor = Gdk.Cursor(Gdk.CursorType.LEFT_PTR)
+        self.get_root_window().set_cursor(sugar_cursor)
+
         self._is_fullscreen = False
         self._unfullscreen_button = UnfullscreenButton()
         self._unfullscreen_button.set_transient_for(self)


### PR DESCRIPTION
Originally Gio.Settings were used to set the cursor. Set the cursor internally in Gdk so it doesn't effect the rest of the system.

Related PR in sugar: https://github.com/sugarlabs/sugar/pull/670