### PR TITLE
Fix regression for GTK2 activities caused by 2f2b2d2

### DIFF
--- a/bin/sugar-activity
+++ b/bin/sugar-activity
@@ -40,6 +40,9 @@ from sugar3 import logger
 from sugar3.bundle.bundle import MalformedBundleException
 
 from distutils.dir_util import mkpath
+import time
+import hashlib
+import random
 
 def create_activity_instance(constructor, handle):
     activity = constructor(handle)
@@ -165,7 +168,10 @@ def main():
     activity_constructor = getattr(module, class_name)
 
     if not options.activity_id:
-        options.activity_id = bundle.get_name()
+        # Generate random hash
+        data = '%s%s' % (time.time(), random.randint(10000, 100000))
+        random_hash = hashlib.sha1(data).hexdigest()
+        options.activity_id = random_hash
         options.bundle_id = bundle.get_bundle_id()
 
     activity_handle = activityhandle.ActivityHandle(

--- a/bin/sugar-activity
+++ b/bin/sugar-activity
@@ -35,10 +35,11 @@ DBusGMainLoop(set_as_default=True)
 from sugar3.activity import activityhandle
 from sugar3 import config
 from sugar3.bundle.activitybundle import ActivityBundle
-from sugar3.activity.activityfactory import get_environment
 from sugar3 import logger
 
 from sugar3.bundle.bundle import MalformedBundleException
+
+from distutils.dir_util import mkpath
 
 def create_activity_instance(constructor, handle):
     activity = constructor(handle)
@@ -124,7 +125,22 @@ def main():
             activity_class = bundle.get_command().split(" ")[1]
 
     if 'SUGAR_VERSION' not in os.environ:
-        environ = get_environment(bundle)
+        profile_id = os.environ.get('SUGAR_PROFILE', 'default')
+        home_dir = os.environ.get('SUGAR_HOME', os.path.expanduser('~/.sugar'))
+        base = os.path.join(home_dir, profile_id)
+        activity_root = os.path.join(base, bundle.get_bundle_id())
+
+        instance_dir = os.path.join(activity_root, 'instance')
+        mkpath(instance_dir)
+
+        data_dir = os.path.join(activity_root, 'data')
+        mkpath(data_dir)
+
+        tmp_dir = os.path.join(activity_root, 'tmp')
+        mkpath(tmp_dir)
+
+        os.environ['SUGAR_ACTIVITY_ROOT'] = activity_root
+        os.environ['SUGAR_BUNDLE_PATH'] = bundle.get_path()
 
     os.environ['SUGAR_BUNDLE_ID'] = bundle.get_bundle_id()
     os.environ['SUGAR_BUNDLE_NAME'] = bundle.get_name()


### PR DESCRIPTION
The issue was caused by importing from activityfactory which caused GObject to be imported. This conflicts with GTK2. (Reported and original patch by James Cameron)
We should create the sugar profile's activity root if it doesn't exist yet, when running outside Sugar. But activity factory can't be used, because of this incompatibility.