### PR TITLE
Ignore empty translated summary

### DIFF
--- a/src/sugar3/activity/bundlebuilder.py
+++ b/src/sugar3/activity/bundlebuilder.py
@@ -144,6 +144,8 @@ class Builder(object):
             cat = gettext.GNUTranslations(open(mo_file, 'r'))
             translated_name = cat.gettext(self.config.activity_name)
             translated_summary = cat.gettext(self.config.summary)
+            if translated_summary is None:
+                translated_summary = ''
             if translated_summary.find('\n') > -1:
                 translated_summary = translated_summary.replace('\n', '')
                 logging.warn(


### PR DESCRIPTION
(cat.gettext can return None, which doesn't have a find method)