### PR TITLE
Allow running GTK3 Sugar Activities in HTML5

### DIFF
--- a/src/sugar3/activity/activity.py
+++ b/src/sugar3/activity/activity.py
@@ -1129,9 +1129,16 @@ class Activity(Window, Gtk.Container):
             self._complete_close()
 
     def __realize_cb(self, window):
-        xid = window.get_window().get_xid()
-        SugarExt.wm_set_bundle_id(xid, self.get_bundle_id())
-        SugarExt.wm_set_activity_id(xid, str(self._activity_id))
+        display_name = Gdk.Display.get_default().get_name()
+        if ':' in display_name: 
+            # X11 for sure; this only works in X11
+            xid = window.get_window().get_xid()
+            SugarExt.wm_set_bundle_id(xid, self.get_bundle_id())
+            SugarExt.wm_set_activity_id(xid, str(self._activity_id))
+        elif display_name is 'Broadway': 
+            # GTK3's HTML5 backend
+            # This is needed so that the window takes the whole browser window
+            self.maximize()
 
     def __delete_event_cb(self, widget, event):
         self.close()


### PR DESCRIPTION
To test:
```
$ broadwayd :5 &
$ BROADWAY_DISPLAY=:5 GDK_BACKEND=broadway SESSION_MANAGER= sugar-activity <Activity Directory or nothing if already in one>
```
Then visit http://localhost:8085/