### PR TITLE
Don't assume all connection managers support Sugar

### DIFF
--- a/src/sugar3/presence/presenceservice.py
+++ b/src/sugar3/presence/presenceservice.py
@@ -91,6 +91,11 @@ class PresenceService(GObject.GObject):
                     if e.get_dbus_name() == name:
                         logging.debug("There's no shared activity with the id "
                                       "%s" % activity_id)
+                    elif e.get_dbus_name() == \
+                         'org.freedesktop.DBus.Error.UnknownMethod':
+                        logging.warning(
+                            'Telepathy Account %r does not support '
+                            'Sugar collaboration', account_path)
                     else:
                         raise
                 else:


### PR DESCRIPTION
If the user has a "random" telepathy connection manager
installed and running on the system (eg. telepathy idle being
active if they are chatting on irc with GNOME's Polari), activities
will crash on startup.

Steps to reproduce the crash:
1. Run Polari (eg. via the Terminal activity)
2. Join an irc channel in Polari (eg. #sugar on freenode)
3. Try to open an activity from the home view
    - notice that opening any sugar3 activity will crash

This is probably very relevant to @icarito GNOME patches, as many GNOME users probably have telepathy or empathy with "random" connection managers.  Steps to reproduce under gnome:

1.  Run Polarai, connected to #sugar on freenode
2.  `cd browse-activity`
3.  `sugar-activity`
-> ```Traceback (most recent call last):
  File "/usr/bin/sugar-activity", line 220, in <module>
    main()
  File "/usr/bin/sugar-activity", line 215, in main
    instance = create_activity_instance(activity_constructor, activity_handle)
  File "/usr/bin/sugar-activity", line 48, in create_activity_instance
    activity = constructor(handle)
  File "/home/saam/sugar-build/activities/browse/webactivity.py", line 150, in __init__
    activity.Activity.__init__(self, handle)
  File "/usr/lib/python2.7/site-packages/sugar3/activity/activity.py", line 430, in __init__
    warn_if_none=False)
  File "/usr/lib/python2.7/site-packages/sugar3/presence/presenceservice.py", line 88, in get_activity
    dbus_interface=CONN_INTERFACE_ACTIVITY_PROPERTIES)
  File "/usr/lib64/python2.7/site-packages/dbus/proxies.py", line 70, in __call__
    return self._proxy_method(*args, **keywords)
  File "/usr/lib64/python2.7/site-packages/dbus/proxies.py", line 145, in __call__
    **keywords)
  File "/usr/lib64/python2.7/site-packages/dbus/connection.py", line 651, in call_blocking
    message, timeout)
dbus.exceptions.DBusException: org.freedesktop.DBus.Error.UnknownMethod: Method "GetActivity" with signature "s" on interface "org.laptop.Telepathy.ActivityProperties" doesn't exist
```