### PR TITLE
Touch Palette invocation fixes

### DIFF
--- a/src/sugar3/graphics/icon.py
+++ b/src/sugar3/graphics/icon.py
@@ -575,7 +575,10 @@ class EventIcon(Gtk.EventBox):
         self.add_events(Gdk.EventMask.BUTTON_PRESS_MASK |
                         Gdk.EventMask.TOUCH_MASK |
                         Gdk.EventMask.BUTTON_RELEASE_MASK)
-        self.connect('button-release-event', self.__button_release_event_cb)
+        # Connect after the default so that the palette can silence events
+        # for example, after a touch palette invocation
+        self.connect_after('button-release-event',
+                           self.__button_release_event_cb)
         for key, value in kwargs.iteritems():
             self.set_property(key, value)
 

--- a/src/sugar3/graphics/palettewindow.py
+++ b/src/sugar3/graphics/palettewindow.py
@@ -1381,6 +1381,7 @@ class CursorInvoker(Invoker):
 
     def __long_pressed_event_cb(self, controller, x, y, widget):
         self._long_pressed_recognized = True
+        x, y = widget.get_window().get_root_coords(x, y)
         self.notify_right_click(x, y)
 
     def get_toplevel(self):


### PR DESCRIPTION
2 fixes for touch palette invocation on the home screen (with the favorite activity icons).  See commit descriptions for steps.