### PR TITLE
Show icons in buttons

### DIFF
--- a/src/sugar3/activity/activity.py
+++ b/src/sugar3/activity/activity.py
@@ -336,6 +336,7 @@ class Activity(Window, Gtk.Container):
         settings = Gtk.Settings.get_default()
         settings.set_property('gtk-theme-name', sugar_theme)
         settings.set_property('gtk-icon-theme-name', 'sugar')
+        settings.set_property('gtk-button-images', True)
         settings.set_property('gtk-font-name',
                               '%s %f' % (style.FONT_FACE, style.FONT_SIZE))
 


### PR DESCRIPTION
Gtk 3.20 recently changed the default setting so that buttons hide
their icons.  This is regression in terms of the Sugar HIG.

Same as https://github.com/sugarlabs/sugar/pull/694, but for activities (not the shell)