### PR TITLE
Unify palette popdowns

### DIFF
--- a/src/sugar3/graphics/palette.py
+++ b/src/sugar3/graphics/palette.py
@@ -123,7 +123,6 @@ class Palette(PaletteWindow):
         self._secondary_text = None
         self._icon = None
         self._icon_visible = True
-        self._palette_state = self.PRIMARY
 
         self._primary_event_box = Gtk.EventBox()
         self._primary_event_box.show()
@@ -165,9 +164,7 @@ class Palette(PaletteWindow):
 
         self._separator = Gtk.HSeparator()
         self._secondary_box.pack_start(self._separator, True, True, 0)
-
-        self._secondary_anim = animator.Animator(2.0, 10)
-        self._secondary_anim.add(_SecondaryAnimation(self))
+        self._secondary_box.show()
 
         # we init after initializing all of our containers
         PaletteWindow.__init__(self, **kwargs)
@@ -186,7 +183,6 @@ class Palette(PaletteWindow):
         self.action_bar.show()
 
         self.connect('notify::invoker', self.__notify_invoker_cb)
-        self.connect('popdown', self.__popdown_cb)
 
         # Default to a normal window palette
         self._content_widget = None
@@ -203,14 +199,10 @@ class Palette(PaletteWindow):
             self._widget.present()
 
     def __destroy_cb(self, palette):
-        self._secondary_anim.stop()
         self.popdown(immediate=True)
         # Break the reference cycle. It looks like the gc is not able to free
         # it, possibly because Gtk.Menu memory handling is very special.
         self._widget = None
-
-    def __popdown_cb(self, widget):
-        self._secondary_anim.stop()
 
     def __notify_invoker_cb(self, palette, pspec):
         invoker = self.props.invoker
@@ -225,33 +217,20 @@ class Palette(PaletteWindow):
     def get_full_size_request(self):
         return self._full_request
 
-    def popup(self, immediate=False, state=None):
+    def popup(self, immediate=False):
         if self._invoker is not None:
             self._update_full_request()
-
-        if state is None:
-            state = self.PRIMARY
-        self.set_palette_state(state)
-
-        if state == self.PRIMARY:
-            self._secondary_anim.start()
-        else:
-            self._secondary_anim.stop()
 
         PaletteWindow.popup(self, immediate)
 
     def popdown(self, immediate=False):
         if immediate:
-            self._secondary_anim.stop()
-            # to suppress glitches while later re-opening
-            self.set_palette_state(self.PRIMARY)
             if self._widget:
                 self._widget.size_request()
         PaletteWindow.popdown(self, immediate)
 
     def on_enter(self):
         PaletteWindow.on_enter(self)
-        self._secondary_anim.start()
 
     def _add_content(self):
         # The content is not shown until a widget is added
@@ -430,26 +409,8 @@ class Palette(PaletteWindow):
         self._widget.set_accept_focus(accept_focus)
 
     def _update_full_request(self):
-        if self._palette_state == self.PRIMARY:
-            self._secondary_box.show()
-
         if self._widget is not None:
             self._full_request = self._widget.size_request()
-
-        if self._palette_state == self.PRIMARY:
-            self._secondary_box.hide()
-
-    def _set_palette_state(self, state):
-        if self._palette_state == state:
-            return
-
-        if state == self.PRIMARY:
-            self._secondary_box.hide()
-        elif state == self.SECONDARY:
-            self._secondary_box.show()
-            self.update_position()
-
-        self._palette_state = state
 
     def get_menu(self):
         assert self._content_widget is None
@@ -475,13 +436,7 @@ class Palette(PaletteWindow):
     menu = GObject.property(type=object, getter=get_menu)
 
     def _invoker_right_click_cb(self, invoker):
-        self.popup(immediate=True, state=self.SECONDARY)
-
-    def _invoker_toggle_state_cb(self, invoker):
-        if self.is_up() and self._palette_state == self.SECONDARY:
-            self.popdown(immediate=True)
-        else:
-            self.popup(immediate=True, state=self.SECONDARY)
+        self.popup(immediate=True)
 
 
 class PaletteActionBar(Gtk.HButtonBox):
@@ -496,14 +451,3 @@ class PaletteActionBar(Gtk.HButtonBox):
 
         self.pack_start(button, True, True, 0)
         button.show()
-
-
-class _SecondaryAnimation(animator.Animation):
-
-    def __init__(self, palette):
-        animator.Animation.__init__(self, 0.0, 1.0)
-        self._palette = palette
-
-    def next_frame(self, current):
-        if current == 1.0:
-            self._palette.set_palette_state(Palette.SECONDARY)

--- a/src/sugar3/graphics/palettewindow.py
+++ b/src/sugar3/graphics/palettewindow.py
@@ -486,9 +486,6 @@ class PaletteWindow(GObject.GObject):
     Provides basic management of child widget, invoker, and animation.
     """
 
-    PRIMARY = 0
-    SECONDARY = 1
-
     __gsignals__ = {
         'popup': (GObject.SignalFlags.RUN_FIRST, None, ([])),
         'popdown': (GObject.SignalFlags.RUN_FIRST, None, ([])),
@@ -502,7 +499,6 @@ class PaletteWindow(GObject.GObject):
         self._cursor_y = 0
         self._alignment = None
         self._up = False
-        self._palette_state = None
         self._widget = None
 
         self._popup_anim = animator.Animator(.5, 10)
@@ -756,17 +752,6 @@ class PaletteWindow(GObject.GObject):
         rect.height = minimum.height
 
         return rect
-
-    def get_palette_state(self):
-        return self._palette_state
-
-    def _set_palette_state(self, state):
-        self._palette_state = state
-
-    def set_palette_state(self, state):
-        self._set_palette_state(state)
-
-    palette_state = property(get_palette_state)
 
 
 class _PopupAnimation(animator.Animation):


### PR DESCRIPTION
Previously there was the concept of having 2 popdowns for a palette.
The first popdown showed the of tooltip the palette, and the 2nd
showed the content of the palette.  However, this was confusing
to new users, and made users wait for little reason.

This commit removes the 2nd popdown.  An example of this is when you
mouse over an icon to invoke the palette.  Previously, it showed
the tooltip, then made you wait, then showed the content of the
palette.  With this patch, the whole palette is shown at the
first popdown, making a snappy UX.

See https://www.sam.today/blog/sugar-with-instant-palettes/ for more background

Mailing list reference:  http://lists.sugarlabs.org/archive/sugar-devel/2016-May/052808.html