### PR TITLE
Version the GdkX11 import, fixes #4965

### DIFF
--- a/src/sugar3/graphics/window.py
+++ b/src/sugar3/graphics/window.py
@@ -20,6 +20,9 @@
 STABLE.
 """
 
+import gi
+gi.require_version('GdkX11', '3.0')
+
 from gi.repository import GObject
 from gi.repository import GLib
 from gi.repository import Gdk


### PR DESCRIPTION
The unversioned import results in the following log noise:

    /usr/lib/python2.7/site-packages/sugar3/graphics/window.py:26: PyGIWarning: GdkX11 was imported without specifying a version first. Use gi.require_version('GdkX11', '3.0') before import to ensure that the right version gets loaded.
      from gi.repository import GdkX11

See @davelab6's ticket at https://bugs.sugarlabs.org/ticket/4965