### PR TITLE
Write docs for constants in sugar3.graphics.style

### DIFF
--- a/src/sugar3/graphics/style.py
+++ b/src/sugar3/graphics/style.py
@@ -156,52 +156,78 @@ def zoom(units):
     return int(ZOOM_FACTOR * units)
 
 
-ZOOM_FACTOR = _compute_zoom_factor()
+ZOOM_FACTOR = _compute_zoom_factor()  #: scale factor, as float (eg. 0.72, 1.0)
 
-DEFAULT_SPACING = zoom(15)
-DEFAULT_PADDING = zoom(6)
-GRID_CELL_SIZE = zoom(75)
-LINE_WIDTH = zoom(2)
+DEFAULT_SPACING = zoom(15)  #: Spacing is placed in-between components
+DEFAULT_PADDING = zoom(6)  #: Padding is placed around a ui component
+GRID_CELL_SIZE = zoom(75)  #: Grid cells are the fundamental measure for sugar
+LINE_WIDTH = zoom(2)  #: Thickness of a separator line
 
+#: icon that fits within a grid cell
 STANDARD_ICON_SIZE = zoom(55)
+#: small icon, used in palette menu items
 SMALL_ICON_SIZE = zoom(33)
+#: larger than standard
 MEDIUM_ICON_SIZE = zoom(55 * 1.5)
+#: larger than medium, used in journal empty view
 LARGE_ICON_SIZE = zoom(55 * 2.0)
+#: larger than large, used in activity pulsing launcher icon
 XLARGE_ICON_SIZE = zoom(55 * 2.75)
 
 if 'org.sugarlabs.font' in Gio.Settings.list_schemas():
     settings = Gio.Settings('org.sugarlabs.font')
+    #: User's preferred font size
     FONT_SIZE = settings.get_double('default-size')
+    #: User's preferred font face
     FONT_FACE = settings.get_string('default-face')
 else:
+    #: User's preferred font size
     FONT_SIZE = 10
-    FONT_FACE = 'Sans Serif' 
+    #: User's preferred font face
+    FONT_FACE = 'Sans Serif'
 
+#: Normal font
 FONT_NORMAL = Font('%s %f' % (FONT_FACE, FONT_SIZE))
+#: Bold font
 FONT_BOLD = Font('%s bold %f' % (FONT_FACE, FONT_SIZE))
+#: Height in pixels of normal font
 FONT_NORMAL_H = zoom(24)
+#: Height in pixels of bold font
 FONT_BOLD_H = zoom(24)
 
+# These constants are unused, as they are for the old style toolbox design
 TOOLBOX_SEPARATOR_HEIGHT = zoom(9)
 TOOLBOX_HORIZONTAL_PADDING = zoom(75)
 TOOLBOX_TAB_VBORDER = int((zoom(36) - FONT_NORMAL_H - FOCUS_LINE_WIDTH) / 2)
 TOOLBOX_TAB_HBORDER = zoom(15) - FOCUS_LINE_WIDTH - _TAB_CURVATURE
 TOOLBOX_TAB_LABEL_WIDTH = zoom(150 - 15 * 2)
 
-COLOR_BLACK = Color('#000000')
-COLOR_WHITE = Color('#FFFFFF')
+COLOR_BLACK = Color('#000000')  #: Black
+COLOR_WHITE = Color('#FFFFFF')  #: White
+#: Fully transparent color
 COLOR_TRANSPARENT = Color('#FFFFFF', alpha=0.0)
+#: Default background color of a window
 COLOR_PANEL_GREY = Color('#C0C0C0')
+#: Background color of selected entry
 COLOR_SELECTION_GREY = Color('#A6A6A6')
+#: Color of toolbars
 COLOR_TOOLBAR_GREY = Color('#282828')
+#: Color of buttons
 COLOR_BUTTON_GREY = Color('#808080')
+#: ???
 COLOR_INACTIVE_FILL = Color('#9D9FA1')
+#: ???
 COLOR_INACTIVE_STROKE = Color('#757575')
+#: Background color of entry
 COLOR_TEXT_FIELD_GREY = Color('#E5E5E5')
+#: Color of highlighted text
 COLOR_HIGHLIGHT = Color('#E7E7E7')
 
+#: Cursor invoked palettes will be placed this far from the cursor
 PALETTE_CURSOR_DISTANCE = zoom(10)
 
+#: Size of arrow displayed under toolbar buttons to represent their status
 TOOLBAR_ARROW_SIZE = zoom(24)
 
+#: Max width of text in a palette menu, in chars
 MENU_WIDTH_CHARS = 60


### PR DESCRIPTION
The constants must be documented, because otherwise they are hidden
from the generated online documentation.
