### PR TITLE
Assign icon to window regardless of environment.

### DIFF
--- a/src/sugar3/activity/activity.py
+++ b/src/sugar3/activity/activity.py
@@ -440,9 +440,8 @@ class Activity(Window, Gtk.Container):
                                            self.__jobject_updated_cb)
         self.set_title(self._jobject.metadata['title'])
 
-        if 'SUGAR_VERSION' not in os.environ:
-            bundle = get_bundle_instance(get_bundle_path())
-            self.set_icon_from_file(bundle.get_icon())
+        bundle = get_bundle_instance(get_bundle_path())
+        self.set_icon_from_file(bundle.get_icon())
 
 
     def run_main_loop(self):


### PR DESCRIPTION
Makes Sugar Activities more standard.

Companion of https://github.com/sugarlabs/sugar-toolkit/pull/5