### PR TITLE
Proper deprecation of Palette.popdown state argument

### DIFF
--- a/src/sugar3/graphics/palette.py
+++ b/src/sugar3/graphics/palette.py
@@ -223,7 +223,19 @@ class Palette(PaletteWindow):
 
         PaletteWindow.popup(self, immediate)
 
-    def popdown(self, immediate=False):
+    def popdown(self, immediate=False, state=None):
+        '''
+        Popdown (or show the full contents of) the palette.
+
+        Keyword Args:
+            immediate (bool): if True, the palette will be shown instantly (as
+                if the user right clicked the item).  If False, the palette
+                will be shown after the usual activation wait time.
+
+        .. deprecated:: 0.109
+            The state keyword argument is deprecated.  The old
+            secondary state has become the only state.
+        '''
         if immediate:
             if self._widget:
                 self._widget.size_request()


### PR DESCRIPTION
The popdown state argument was removed in 90cec5b, as the palette
popdowns were unified.  However, this is a public api.  Removing
the argument caused exceptions to be raised, breaking applications.
Most uses of the state argument were for the SECONDARY state, which
is now the default behaviour.

This commit re-adds the argument with a deprecation notice.