### PR TITLE
Fix screen resize race

### DIFF
--- a/src/sugar3/activity/activity.py
+++ b/src/sugar3/activity/activity.py
@@ -626,12 +626,12 @@ class Activity(Window, Gtk.Container):
 
     def _adapt_window_to_screen(self):
         screen = Gdk.Screen.get_default()
-        workarea = screen.get_monitor_workarea(screen.get_number())
+        rect = screen.get_monitor_geometry(screen.get_number())
         geometry = Gdk.Geometry()
         geometry.max_width = geometry.base_width = geometry.min_width = \
-            workarea.width
+            rect.width
         geometry.max_height = geometry.base_height = geometry.min_height = \
-            workarea.height
+            rect.height
         geometry.width_inc = geometry.height_inc = geometry.min_aspect = \
             geometry.max_aspect = 1
         hints = Gdk.WindowHints(Gdk.WindowHints.ASPECT |


### PR DESCRIPTION
When an external monitor is connected or disconnected, about 25% of the time an activity does not resize correctly; a `size-changed` signal occurs but the workarea geometry has not changed.

Underlying problem is an update race in `get_monitor_workarea`, so the fix is to call `get_monitor_geometry` for obtaining the width and height.

Can be reproduced easily without an external monitor by switching display panel resolution repeatedly;
```
    xrandr --output eDP1 --mode 1024x768
    xrandr --output eDP1 --mode 1366x768
```
Part of a fix for https://bugs.sugarlabs.org/ticket/4968

----
Related pull request https://github.com/sugarlabs/sugar/pull/732 can be merged in any order with this pull request; the patches are independent but solve the same problem in two different contexts.