### PR TITLE
Check if file is directory. Fixes sugar-build build browse error.

### DIFF
--- a/src/sugar3/activity/bundlebuilder.py
+++ b/src/sugar3/activity/bundlebuilder.py
@@ -365,7 +365,10 @@ class Installer(Packager):
             if not os.path.exists(path):
                 os.makedirs(path)
 
-            shutil.copy(source, dest)
+            if os.path.isdir(source):
+                shutil.copytree(source, dest)
+            else:
+                shutil.copy(source, dest)
 
         if install_mime:
             self.config.bundle.install_mime_type(self.config.source_dir)


### PR DESCRIPTION
Now, bundlebuilder checks if the file to copy is a dir.
If it's a dir, it uses "shutil.copytree" instead of "shutil.copy".
This fixes the error when building browse (or other activities?) in sugar-build.

Fixes https://github.com/sugarlabs/sugar-build/issues/41