### PR TITLE
Added documentation and example for progressicon

### DIFF
--- a/examples/progressicon.py
+++ b/examples/progressicon.py
@@ -1,0 +1,57 @@
+from gi.repository import Gtk
+from gi.repository import GObject
+
+from sugar3.graphics.toolbarbox import ToolbarBox
+from sugar3.graphics.progressicon import ProgressIcon
+from sugar3.graphics.icon import Icon, get_surface
+from sugar3.graphics import style
+
+import common
+
+
+test = common.Test()
+
+vbox = Gtk.VBox()
+test.pack_start(vbox, True, True, 0)
+
+toolbar_box = ToolbarBox()
+vbox.pack_start(toolbar_box, False, False, 0)
+
+separator = Gtk.SeparatorToolItem()
+toolbar_box.toolbar.insert(separator, -1)
+
+icon = ProgressIcon(
+      pixel_size=style.LARGE_ICON_SIZE,
+      icon_name='computer-xo',
+      stroke_color=style.COLOR_BUTTON_GREY.get_svg(),
+      fill_color=style.COLOR_WHITE.get_svg())
+test.pack_start(icon, True, True, 0)
+icon.show()
+
+icon2 = ProgressIcon(
+    pixel_size=style.LARGE_ICON_SIZE,
+    icon_name='computer-xo',
+    stroke_color=style.COLOR_BUTTON_GREY.get_svg(),
+    fill_color=style.COLOR_WHITE.get_svg(),
+    direction='horizontal')
+test.pack_start(icon2, True, True, 0)
+icon2.show()
+
+test.show_all()
+
+progress = 0
+
+
+def timeout_cb():
+    global progress
+    progress += 0.05
+    icon.update(progress)
+    icon2.update(progress)
+    if progress >= 1:
+        return False
+    return True
+
+GObject.timeout_add(50, timeout_cb)
+
+if __name__ == '__main__':
+    common.main(test)

--- a/src/sugar3/graphics/progressicon.py
+++ b/src/sugar3/graphics/progressicon.py
@@ -38,16 +38,15 @@ class ProgressIcon(Gtk.DrawingArea):
 
     Args:
 
-      pixel_size(integer): sets the icon size
+      pixel_size (integer): sets the icon size
          [e.g. pixel_size=style.LARGE_ICON_SIZE]
 
-      icon_name(string): Name of icon
+      icon_name (string): Name of icon
          [e.g. icon_name='test_icon']
 
-      stroke_color(string): Stroke color means border color.
-         [e.g.stroke_color=style.COLOR_BUTTON_RED.get_svg()]
+      stroke_color (string): Stroke color means border color.
 
-      fill_color(string): The main (inside) color of progressicon
+      fill_color (string): The main (inside) color of progressicon
          [e.g. fill_color=style.COLOR_BLUE.get_svg()
     '''
     def __init__(self, icon_name, pixel_size, stroke_color, fill_color,

--- a/src/sugar3/graphics/progressicon.py
+++ b/src/sugar3/graphics/progressicon.py
@@ -15,8 +15,8 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 '''
-The progressicon module provides a progress icon; a widget like progress
-bar which shows progress of a task
+The progressicon module provides a progress icon.
+A progress icon is a progress indicator in the form of an icon.
 '''
 
 from gi.repository import Gtk

--- a/src/sugar3/graphics/progressicon.py
+++ b/src/sugar3/graphics/progressicon.py
@@ -24,7 +24,7 @@ from sugar3.graphics import style
 
 
 class ProgressIcon(Gtk.DrawingArea):
-    """
+    '''
     Display the progress filling the icon.
 
     This class is compatible with the sugar3.graphics.icon.Icon class.
@@ -38,7 +38,7 @@ class ProgressIcon(Gtk.DrawingArea):
 
     Args:
 
-      pixel_size(string): sets the icon size
+      pixel_size(integer): sets the icon size
          [e.g. pixel_size=style.LARGE_ICON_SIZE]
 
       icon_name(string): Name of icon
@@ -49,7 +49,7 @@ class ProgressIcon(Gtk.DrawingArea):
 
       fill_color(string): The main (inside) color of progressicon
          [e.g. fill_color=style.COLOR_BLUE.get_svg()
-    """
+    '''
     def __init__(self, icon_name, pixel_size, stroke_color, fill_color,
                  direction='vertical'):
         Gtk.DrawingArea.__init__(self)

--- a/src/sugar3/graphics/progressicon.py
+++ b/src/sugar3/graphics/progressicon.py
@@ -14,6 +14,10 @@
 # License along with this library; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
+'''
+The progressicon module provides a progress icon; a widget like progress
+bar which shows progress of a task
+'''
 
 from gi.repository import Gtk
 from sugar3.graphics.icon import get_surface
@@ -21,7 +25,8 @@ from sugar3.graphics import style
 
 
 class ProgressIcon(Gtk.DrawingArea):
-    """Display the progress filling the icon.
+    """
+    Display the progress filling the icon.
 
     This class is compatible with the sugar3.graphics.icon.Icon class.
 
@@ -32,6 +37,19 @@ class ProgressIcon(Gtk.DrawingArea):
     it will be filled from right to left or from left to right,
     depending on the system's language RTL setting.
 
+    Parameters:
+
+      pixel_size - sets the icon size
+         [e.g. pixel_size=style.LARGE_ICON_SIZE]
+
+      icon_name - Name of icon
+         [e.g. icon_name='test_icon']
+
+      stroke color - Stroke color means border color.
+         [e.g.stroke_color=style.COLOR_BUTTON_RED.get_svg()]
+
+      fill_color - The main (inside) color of progressicon
+         [e.g. fill_color=style.COLOR_BLUE.get_svg()
     """
     def __init__(self, icon_name, pixel_size, stroke_color, fill_color,
                  direction='vertical'):
@@ -95,5 +113,9 @@ class ProgressIcon(Gtk.DrawingArea):
         return (height, height)
 
     def update(self, progress):
+        '''
+        Updates progressicon with progress's value.
+        Example: update(0.9)
+        '''
         self._progress = progress
         self.queue_draw()

--- a/src/sugar3/graphics/progressicon.py
+++ b/src/sugar3/graphics/progressicon.py
@@ -15,7 +15,6 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 '''
-The progressicon module provides a progress icon.
 A progress icon is a progress indicator in the form of an icon.
 '''
 
@@ -37,18 +36,18 @@ class ProgressIcon(Gtk.DrawingArea):
     it will be filled from right to left or from left to right,
     depending on the system's language RTL setting.
 
-    Parameters:
+    Args:
 
-      pixel_size - sets the icon size
+      pixel_size(string): sets the icon size
          [e.g. pixel_size=style.LARGE_ICON_SIZE]
 
-      icon_name - Name of icon
+      icon_name(string): Name of icon
          [e.g. icon_name='test_icon']
 
-      stroke color - Stroke color means border color.
+      stroke_color(string): Stroke color means border color.
          [e.g.stroke_color=style.COLOR_BUTTON_RED.get_svg()]
 
-      fill_color - The main (inside) color of progressicon
+      fill_color(string): The main (inside) color of progressicon
          [e.g. fill_color=style.COLOR_BLUE.get_svg()
     """
     def __init__(self, icon_name, pixel_size, stroke_color, fill_color,
@@ -105,10 +104,16 @@ class ProgressIcon(Gtk.DrawingArea):
         cr.paint()
 
     def do_get_preferred_width(self):
+        '''
+        Calculate the minimum and natural width of the progressicon.
+        '''
         width = self._stroke.get_width()
         return (width, width)
 
     def do_get_preferred_height(self):
+        '''
+        Calculate the minimum and natural height of the progressicon.
+        '''
         height = self._stroke.get_height()
         return (height, height)
 


### PR DESCRIPTION
I've documented progressicon.py and created example. 
From my previous work : https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/299
My previous work didn't include an example. I've added it now. 