### PR TITLE
Example fixes

### DIFF
--- a/examples/alert.py
+++ b/examples/alert.py
@@ -1,10 +1,7 @@
 from gi.repository import Gtk
-
 from sugar3.graphics.alert import TimeoutAlert
-
-
-def _destroy_cb(widget, data=None):
-    Gtk.main_quit()
+from common import set_theme
+set_theme()
 
 
 def __start_response_cb(widget, data=None):
@@ -12,9 +9,9 @@ def __start_response_cb(widget, data=None):
 
 
 w = Gtk.Window()
-w.connect("destroy", _destroy_cb)
+w.connect("delete-event", Gtk.main_quit)
 
-box = Gtk.VBox()
+box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 w.add(box)
 
 alert = TimeoutAlert(9)

--- a/examples/animator.py
+++ b/examples/animator.py
@@ -4,8 +4,12 @@ from sugar3.graphics import animator
 from sugar3.graphics.icon import Icon
 from sugar3.graphics import style
 
+from common import set_theme
+set_theme()
+
 
 class _Animation(animator.Animation):
+
     def __init__(self, icon, start_size, end_size):
         animator.Animation.__init__(self, 0.0, 1.0)
 
@@ -22,14 +26,10 @@ def __animation_completed_cb(anim):
     print 'Animation completed'
 
 
-def _destroy_cb(widget, data=None):
-    Gtk.main_quit()
-
-
 w = Gtk.Window()
-w.connect("destroy", _destroy_cb)
+w.connect('delete-event', Gtk.main_quit)
 
-box = Gtk.VBox()
+box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 w.add(box)
 
 anim = animator.Animator(5)

--- a/examples/buttons.py
+++ b/examples/buttons.py
@@ -6,57 +6,57 @@ import common
 test = common.Test()
 test.show()
 
-vbox = Gtk.VBox()
-test.pack_start(vbox, True, True, 0)
-vbox.show()
+box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+test.pack_start(box, True, True, 0)
+box.show()
 
 # test Gtk.SpinButton:
 
 adj = Gtk.Adjustment(0, 0, 10, 1, 32, 0)
 spin = Gtk.SpinButton()
 spin.set_adjustment(adj)
-vbox.pack_start(spin, False, False, 1)
+box.pack_start(spin, False, False, 1)
 spin.show()
 
 # test Gtk.RadioButton:
 
 radio_1 = Gtk.RadioButton.new_with_label_from_widget(None, 'Radio 1')
-vbox.pack_start(radio_1, False, False, 1)
+box.pack_start(radio_1, False, False, 1)
 radio_1.show()
 radio_2 = Gtk.RadioButton.new_with_label_from_widget(radio_1, 'Radio 2')
-vbox.pack_start(radio_2, False, False, 1)
+box.pack_start(radio_2, False, False, 1)
 radio_2.show()
 radio_3 = Gtk.RadioButton.new_with_label_from_widget(radio_1, 'Radio 3')
-vbox.pack_start(radio_3, False, False, 1)
+box.pack_start(radio_3, False, False, 1)
 radio_3.show()
 
 # test Gtk.CheckButton:
 
 check_1 = Gtk.CheckButton('Check 1')
-vbox.pack_start(check_1, False, False, 1)
+box.pack_start(check_1, False, False, 1)
 check_1.show()
 
 check_2 = Gtk.CheckButton('Check 2')
-vbox.pack_start(check_2, False, False, 1)
+box.pack_start(check_2, False, False, 1)
 check_2.show()
 
 # test Gtk.Button:
 
 button = Gtk.Button('Button')
-vbox.pack_start(button, False, False, 1)
+box.pack_start(button, False, False, 1)
 button.show()
 
 # test Gtk.Button insensitive:
 
 insensitive_button = Gtk.Button('Insensitive Button')
-vbox.pack_start(insensitive_button, False, False, 1)
+box.pack_start(insensitive_button, False, False, 1)
 insensitive_button.props.sensitive = False
 insensitive_button.show()
 
 # test Gtk.ToggleButton:
 
 toggle_button = Gtk.ToggleButton('ToggleButton')
-vbox.pack_start(toggle_button, False, False, 1)
+box.pack_start(toggle_button, False, False, 1)
 toggle_button.show()
 
 

--- a/examples/colorbutton.py
+++ b/examples/colorbutton.py
@@ -10,20 +10,22 @@ import common
 test = common.Test()
 test.show()
 
-vbox = Gtk.VBox()
-test.pack_start(vbox, True, True, 0)
-vbox.show()
+box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+test.pack_start(box, True, True, 0)
+box.show()
 
 toolbar_box = ToolbarBox()
-vbox.pack_start(toolbar_box, False, False, 0)
+box.pack_start(toolbar_box, False, False, 0)
 toolbar_box.show()
 
 separator = Gtk.SeparatorToolItem()
 toolbar_box.toolbar.insert(separator, -1)
 separator.show()
 
+
 def color_changed_cb(button, pspec):
     print button.get_color()
+
 
 color_button = ColorToolButton()
 color_button.connect("notify::color", color_changed_cb)

--- a/examples/combobox.py
+++ b/examples/combobox.py
@@ -1,6 +1,8 @@
 from gi.repository import Gtk
 
 from sugar3.graphics.combobox import ComboBox
+from common import set_theme
+set_theme()
 
 
 def __combo_changed_cb(combo):
@@ -8,7 +10,7 @@ def __combo_changed_cb(combo):
 
 
 w = Gtk.Window()
-w.connect("destroy", Gtk.main_quit)
+w.connect("delete-event", Gtk.main_quit)
 
 combo = ComboBox()
 combo.append_item(True, 'one')

--- a/examples/common.py
+++ b/examples/common.py
@@ -33,15 +33,16 @@ def set_theme():
     settings.set_property('gtk-icon-theme-name', 'sugar')
 
 
-set_theme()
+class Test(Gtk.Box):
 
-
-class Test(Gtk.VBox):
     def __init__(self):
-        GObject.GObject.__init__(self)
+        GObject.GObject.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+
+        set_theme()
 
 
 class TestPalette(Test):
+
     def __init__(self):
         Test.__init__(self)
 
@@ -51,7 +52,7 @@ class TestPalette(Test):
         toolbar.insert(self._invoker, -1)
         self._invoker.show()
 
-        self.pack_start(toolbar, False)
+        self.pack_start(toolbar, False, False, 0)
         toolbar.show()
 
     def set_palette(self, palette):
@@ -59,9 +60,10 @@ class TestPalette(Test):
 
 
 class TestRunner(object):
+
     def run(self, test):
         window = Gtk.Window()
-        window.connect('destroy', lambda w: Gtk.main_quit())
+        window.connect('delete-event', Gtk.main_quit)
         window.add(test)
         test.show()
 

--- a/examples/customdestroy.py
+++ b/examples/customdestroy.py
@@ -8,6 +8,7 @@ We can do the cleanup in the python destructor method instead.
 
 
 class MyCellRenderer(Gtk.CellRenderer):
+
     def __init__(self):
         Gtk.CellRenderer.__init__(self)
 

--- a/examples/gtktreesensitive.py
+++ b/examples/gtktreesensitive.py
@@ -1,26 +1,25 @@
 #!/usr/bin/python
 from gi.repository import Gtk
 
-
 import common
 test = common.Test()
 test.show()
 
 
-class MyBox(Gtk.VBox):
+class MyBox(Gtk.Box):
 
     def __init__(self):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
 
-        self.scrolled = Gtk.ScrolledWindow()
-        self.scrolled.set_policy(Gtk.PolicyType.AUTOMATIC,
-                                 Gtk.PolicyType.AUTOMATIC)
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_policy(Gtk.PolicyType.AUTOMATIC,
+                            Gtk.PolicyType.AUTOMATIC)
 
-        self.store = Gtk.ListStore(str, str)
+        store = Gtk.ListStore(str, str)
         for i in range(5):
-            self.store.append([str(i), 'Item %s' % i])
+            store.append([str(i), 'Item %s' % i])
 
-        self.treeview = Gtk.TreeView(self.store)
+        treeview = Gtk.TreeView(store)
         renderer_no_sens = Gtk.CellRendererText()
         # set 'sensitive' property
         renderer_no_sens.set_property('sensitive', False)
@@ -29,21 +28,21 @@ class MyBox(Gtk.VBox):
 
         column = Gtk.TreeViewColumn('\'sensitive\' False',
                                     renderer_no_sens, text=0)
-        self.treeview.append_column(column)
+        treeview.append_column(column)
 
         column = Gtk.TreeViewColumn('\'sensitive\' True',
                                     renderer, text=1)
-        self.treeview.append_column(column)
+        treeview.append_column(column)
 
-        self.scrolled.add(self.treeview)
-        self.add(self.scrolled)
+        scrolled.add(treeview)
+        self.pack_start(scrolled, True, True, 0)
 
         self.show_all()
 
 
-vbox = MyBox()
-test.pack_start(vbox, True, True, 0)
-vbox.show()
+box = MyBox()
+test.pack_start(box, True, True, 0)
+box.show()
 
 if __name__ == '__main__':
     common.main(test)

--- a/examples/iconbadges.py
+++ b/examples/iconbadges.py
@@ -12,15 +12,15 @@ import common
 test = common.Test()
 test.show()
 
-vbox = Gtk.VBox()
-test.pack_start(vbox, True, True, 0)
-vbox.show()
+box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+test.pack_start(box, True, True, 0)
+box.show()
 
 # An XO Icon, normal size, setting the color via the XoColor object
 icon = Icon(icon_name='computer-xo',
             pixel_size=style.STANDARD_ICON_SIZE,
             xo_color=XoColor('#00BEFF,#FF7800'))
-vbox.pack_start(icon, False, False, 0)
+box.pack_start(icon, False, False, 0)
 icon.show()
 
 # You can mix constructor keyword argument and setting
@@ -34,7 +34,7 @@ icon.props.fill_color = 'rgb(230, 0, 10)'
 icon.props.stroke_color = '#78E600'
 # Unlike normal icons, EventIcons support palettes:
 icon.props.palette = Palette('Hello World')
-vbox.pack_start(icon, False, False, 0)
+box.pack_start(icon, False, False, 0)
 icon.show()
 
 

--- a/examples/iconcache.py
+++ b/examples/iconcache.py
@@ -23,6 +23,7 @@ from gi.repository import Gtk
 
 from sugar3.graphics.icon import Icon
 from sugar3.graphics.xocolor import XoColor
+from sugar3.graphics import style
 
 import common
 
@@ -55,7 +56,7 @@ def _button_activated_cb(button):
 
 for d in data:
     icon = Icon(icon_name=d[0],
-                icon_size=Gtk.IconSize.LARGE_TOOLBAR,
+                pixel_size=style.STANDARD_ICON_SIZE,
                 xo_color=XoColor(d[1]))
     test.pack_start(icon, True, True, 0)
     icon.show()

--- a/examples/iconentry.py
+++ b/examples/iconentry.py
@@ -1,10 +1,8 @@
 from gi.repository import Gtk
 
 from sugar3.graphics import iconentry
-
-
-def _destroy_cb(widget, data=None):
-    Gtk.main_quit()
+from common import set_theme
+set_theme()
 
 
 def __go_next_cb(entry, icon_pos, data=None):
@@ -16,9 +14,9 @@ def __entry_activate_cb(widget, data=None):
 
 
 w = Gtk.Window()
-w.connect("destroy", _destroy_cb)
+w.connect("delete-event", Gtk.main_quit)
 
-box = Gtk.VBox()
+box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 w.add(box)
 
 entry = iconentry.IconEntry()

--- a/examples/iconwidget.py
+++ b/examples/iconwidget.py
@@ -23,44 +23,45 @@ from gi.repository import Gtk
 
 from sugar3.graphics.icon import Icon
 from sugar3.graphics.xocolor import XoColor
+from sugar3.graphics import style
 
 import common
 
 test = common.Test()
 
-hbox = Gtk.HBox()
-test.pack_start(hbox, True, True, 0)
-sensitive_box = Gtk.VBox()
-insensitive_box = Gtk.VBox()
+box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+test.pack_start(box, True, True, 0)
+sensitive_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+insensitive_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
-hbox.pack_start(sensitive_box, True, True, 0)
-hbox.pack_start(insensitive_box, True, True, 0)
-hbox.show_all()
+box.pack_start(sensitive_box, True, True, 0)
+box.pack_start(insensitive_box, True, True, 0)
+box.show_all()
 
 
 def create_icon_widgets(box, sensitive=True):
     icon = Icon(icon_name='go-previous')
-    icon.props.icon_size = Gtk.IconSize.LARGE_TOOLBAR
+    icon.props.pixel_size = style.STANDARD_ICON_SIZE
     box.pack_start(icon, True, True, 0)
     icon.set_sensitive(sensitive)
     icon.show()
 
     icon = Icon(icon_name='computer-xo',
-                icon_size=Gtk.IconSize.LARGE_TOOLBAR,
+                pixel_size=style.STANDARD_ICON_SIZE,
                 xo_color=XoColor())
     box.pack_start(icon, True, True, 0)
     icon.set_sensitive(sensitive)
     icon.show()
 
     icon = Icon(icon_name='battery-000',
-                icon_size=Gtk.IconSize.LARGE_TOOLBAR,
+                pixel_size=style.STANDARD_ICON_SIZE,
                 badge_name='emblem-busy')
     box.pack_start(icon, True, True, 0)
     icon.set_sensitive(sensitive)
     icon.show()
 
     icon = Icon(icon_name='gtk-new',
-                icon_size=Gtk.IconSize.LARGE_TOOLBAR,
+                pixel_size=style.STANDARD_ICON_SIZE,
                 badge_name='gtk-cancel')
     box.pack_start(icon, True, True, 0)
     icon.set_sensitive(sensitive)

--- a/examples/notebook.py
+++ b/examples/notebook.py
@@ -1,24 +1,22 @@
 from gi.repository import Gtk
 
 from sugar3.graphics.notebook import Notebook
-
-
-def _destroy_cb(widget, data=None):
-    Gtk.main_quit()
+from common import set_theme
+set_theme()
 
 
 w = Gtk.Window()
-w.connect("destroy", _destroy_cb)
+w.connect("delete-event", Gtk.main_quit)
 
-box = Gtk.VBox()
+box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 w.add(box)
 
 nb = Notebook(can_close_tabs=True)
 box.pack_start(nb, False, False, 0)
 
 for i in range(5):
-    bufferf = "Prepend Frame %d" % (i+1)
-    bufferl = "PPage %d" % (i+1)
+    bufferf = "Prepend Frame %d" % (i + 1)
+    bufferl = "PPage %d" % (i + 1)
 
     frame = Gtk.Frame()
     frame.set_border_width(10)

--- a/examples/progress.py
+++ b/examples/progress.py
@@ -6,7 +6,7 @@ import common
 test = common.Test()
 test.show()
 
-box = Gtk.HBox()
+box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
 test.pack_start(box, True, False, 10)
 box.show()
 

--- a/examples/progressicon.py
+++ b/examples/progressicon.py
@@ -10,20 +10,20 @@ import common
 
 test = common.Test()
 
-vbox = Gtk.VBox()
-test.pack_start(vbox, True, True, 0)
+box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+test.pack_start(box, True, True, 0)
 
 toolbar_box = ToolbarBox()
-vbox.pack_start(toolbar_box, False, False, 0)
+box.pack_start(toolbar_box, False, False, 0)
 
 separator = Gtk.SeparatorToolItem()
 toolbar_box.toolbar.insert(separator, -1)
 
 icon = ProgressIcon(
-      pixel_size=style.LARGE_ICON_SIZE,
-      icon_name='computer-xo',
-      stroke_color=style.COLOR_BUTTON_GREY.get_svg(),
-      fill_color=style.COLOR_WHITE.get_svg())
+    pixel_size=style.LARGE_ICON_SIZE,
+    icon_name='computer-xo',
+    stroke_color=style.COLOR_BUTTON_GREY.get_svg(),
+    fill_color=style.COLOR_WHITE.get_svg())
 test.pack_start(icon, True, True, 0)
 icon.show()
 

--- a/examples/radiopalette.py
+++ b/examples/radiopalette.py
@@ -3,14 +3,17 @@ from gi.repository import Gtk
 from sugar3.graphics.radiopalette import RadioPalette, RadioMenuButton, \
     RadioToolsButton
 from sugar3.graphics.radiotoolbutton import RadioToolButton
+from common import set_theme
+set_theme()
+
 
 window = Gtk.Window()
 
-box = Gtk.VBox()
+box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 window.add(box)
 
 toolbar = Gtk.Toolbar()
-box.pack_start(toolbar, False)
+box.pack_start(toolbar, False, False, 0)
 
 text_view = Gtk.TextView()
 box.pack_start(text_view, True, True, 0)
@@ -70,5 +73,6 @@ palette.append(button, 'menu.document-send')
 button = RadioToolsButton(palette=palette)
 toolbar.insert(button, -1)
 
+window.connect('delete-event', Gtk.main_quit)
 window.show_all()
 Gtk.main()

--- a/examples/radiotoolbutton.py
+++ b/examples/radiotoolbutton.py
@@ -1,15 +1,17 @@
 from gi.repository import Gtk
-
 from sugar3.graphics.radiotoolbutton import RadioToolButton
 from sugar3.graphics.radiopalette import RadioPalette, RadioMenuButton
 from sugar3.graphics.xocolor import XoColor
 
 
+from common import set_theme
+set_theme()
+
 window = Gtk.Window()
 window.show()
-window.connect("destroy", Gtk.main_quit)
+window.connect("delete-event", Gtk.main_quit)
 
-box = Gtk.HBox()
+box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
 window.add(box)
 box.show()
 

--- a/examples/scrollingdetector.py
+++ b/examples/scrollingdetector.py
@@ -29,7 +29,7 @@ model = Gtk.ListStore(str)
 data_dir = os.getenv('GTK_DATA_PREFIX', '/usr/')
 
 iconlist = os.listdir(os.path.join(data_dir,
-                      'share/icons/sugar/scalable/actions/'))
+                                   'share/icons/sugar/scalable/actions/'))
 print "Displaying %s icons" % len(iconlist)
 for icon in iconlist:
     icon = os.path.basename(icon)

--- a/examples/tabs.py
+++ b/examples/tabs.py
@@ -7,7 +7,7 @@ import common
 test = common.Test()
 test.show()
 
-box = Gtk.HBox()
+box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
 test.pack_start(box, True, True, 0)
 box.show()
 
@@ -18,7 +18,7 @@ box.pack_start(notebook, True, True, 0)
 notebook.show()
 
 for i in range(3):
-    hbox = Gtk.HBox()
+    hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
     notebook.append_page(hbox, Gtk.Label('Page %d' % (i + 1)))
     hbox.show()
 
@@ -38,7 +38,7 @@ notebook.set_action_widget(button, Gtk.PackType.END)
 button.show()
 
 for i in range(3):
-    hbox = Gtk.HBox()
+    hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
     notebook.append_page(hbox, Gtk.Label('Page %d' % (i + 1)))
     hbox.show()
 

--- a/examples/ticket2855.py
+++ b/examples/ticket2855.py
@@ -25,6 +25,7 @@ from gi.repository import Gtk
 
 from sugar3.graphics.palette import Palette
 from sugar3.graphics.icon import Icon
+from sugar3.graphics import style
 
 import common
 
@@ -33,23 +34,23 @@ test = common.TestPalette()
 palette = Palette('Test radio and toggle')
 test.set_palette(palette)
 
-box = Gtk.HBox()
+box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
 
 toggle = Gtk.ToggleButton()
 
-icon = Icon(icon_name='go-previous', icon_size=Gtk.IconSize.LARGE_TOOLBAR)
+icon = Icon(icon_name='go-previous', pixel_size=style.STANDARD_ICON_SIZE)
 toggle.set_image(icon)
 
-box.pack_start(toggle, False)
+box.pack_start(toggle, False, False, 0)
 toggle.show()
 
 radio = Gtk.RadioButton()
 
-icon = Icon(icon_name='go-next', icon_size=Gtk.IconSize.LARGE_TOOLBAR)
+icon = Icon(icon_name='go-next', pixel_size=style.STANDARD_ICON_SIZE)
 radio.set_image(icon)
 
 radio.set_mode(False)
-box.pack_start(radio, False)
+box.pack_start(radio, False, False, 0)
 radio.show()
 
 palette.set_content(box)

--- a/examples/ticket3000.py
+++ b/examples/ticket3000.py
@@ -28,7 +28,7 @@ import common
 test = common.Test()
 
 toolbar = Gtk.Toolbar()
-test.pack_start(toolbar, False)
+test.pack_start(toolbar, False, False, 0)
 toolbar.show()
 
 button = ToolButton('go-previous')

--- a/examples/toggletoolbutton.py
+++ b/examples/toggletoolbutton.py
@@ -9,12 +9,12 @@ import common
 test = common.Test()
 test.show()
 
-vbox = Gtk.VBox()
-test.pack_start(vbox, True, True, 0)
-vbox.show()
+box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+test.pack_start(box, True, True, 0)
+box.show()
 
 toolbar_box = ToolbarBox()
-vbox.pack_start(toolbar_box, False, False, 0)
+box.pack_start(toolbar_box, False, False, 0)
 toolbar_box.show()
 
 favorite_button = ToggleToolButton('emblem-favorite')

--- a/examples/toolbar.py
+++ b/examples/toolbar.py
@@ -2,14 +2,17 @@ from gi.repository import Gtk
 
 from sugar3.graphics.toolbutton import ToolButton
 from sugar3.graphics.toolbarbox import ToolbarBox, ToolbarButton
+from common import set_theme
+set_theme()
+
 
 window = Gtk.Window()
 
-box = Gtk.VBox()
+box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 window.add(box)
 
 toolbar = ToolbarBox()
-box.pack_start(toolbar, False)
+box.pack_start(toolbar, False, False, 0)
 
 tollbarbutton_1 = ToolbarButton(
     page=Gtk.Button('sub-widget #1'),
@@ -48,5 +51,6 @@ tollbarbutton_4 = ToolbarButton(
     icon_name='document-save')
 toolbar.toolbar.insert(tollbarbutton_4, -1)
 
+window.connect('delete-event', Gtk.main_quit)
 window.show_all()
 Gtk.main()

--- a/examples/toolbarpalettes.py
+++ b/examples/toolbarpalettes.py
@@ -28,12 +28,12 @@ import common
 
 test = common.Test()
 
-vbox = Gtk.VBox()
+box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
 theme_icons = Gtk.IconTheme.get_default().list_icons()
 
 toolbar = Gtk.Toolbar()
-vbox.pack_start(toolbar, False)
+box.pack_start(toolbar, False, False, 0)
 toolbar.show()
 
 for i in range(0, 5):
@@ -43,11 +43,11 @@ for i in range(0, 5):
     button.show()
 
 content = Gtk.Label()
-vbox.pack_start(content, True, True, 0)
+box.pack_start(content, True, True, 0)
 content.show()
 
 tray = HTray()
-vbox.pack_start(tray, False)
+box.pack_start(tray, False, False, 0)
 tray.show()
 
 for i in range(0, 30):
@@ -56,8 +56,8 @@ for i in range(0, 30):
     tray.add_item(button)
     button.show()
 
-test.pack_start(vbox, True, True, 0)
-vbox.show()
+test.pack_start(box, True, True, 0)
+box.show()
 
 test.show()
 

--- a/examples/toolbutton.py
+++ b/examples/toolbutton.py
@@ -8,11 +8,11 @@ import common
 
 test = common.Test()
 
-vbox = Gtk.VBox()
-test.pack_start(vbox, True, True, 0)
+box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+test.pack_start(box, True, True, 0)
 
 toolbar_box = ToolbarBox()
-vbox.pack_start(toolbar_box, False, False, 0)
+box.pack_start(toolbar_box, False, False, 0)
 
 separator = Gtk.SeparatorToolItem()
 toolbar_box.toolbar.insert(separator, -1)
@@ -20,7 +20,7 @@ toolbar_box.toolbar.insert(separator, -1)
 
 def __clicked_cb(button):
     n = int(button.get_tooltip())
-    button.set_tooltip(str(n+1))
+    button.set_tooltip(str(n + 1))
     print "tool button click count %d" % n
 
 

--- a/examples/toolbuttons.py
+++ b/examples/toolbuttons.py
@@ -11,12 +11,12 @@ import common
 test = common.Test()
 test.show()
 
-vbox = Gtk.VBox()
-test.pack_start(vbox, True, True, 0)
-vbox.show()
+box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+test.pack_start(box, True, True, 0)
+box.show()
 
 toolbar_box = ToolbarBox()
-vbox.pack_start(toolbar_box, False, False, 0)
+box.pack_start(toolbar_box, False, False, 0)
 toolbar_box.show()
 
 radial_button = RadioToolButton(icon_name='view-radial')

--- a/examples/tray.py
+++ b/examples/tray.py
@@ -28,7 +28,7 @@ import common
 
 test = common.Test()
 
-vbox = Gtk.VBox()
+vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
 tray = HTray()
 vbox.pack_start(tray, False, False, 0)
@@ -50,7 +50,7 @@ for i in range(0, 10):
     tray.add_item(icon)
     icon.show()
 
-hbox = Gtk.HBox()
+hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
 
 tray = VTray()
 hbox.pack_start(tray, False, False, 0)


### PR DESCRIPTION
- replaced Gtk.HBox/Gtk.VBox by GtkBox as seen in [1] and [2]
GtkHbox and GtkVBox are deprecated
- use delete-event instead of destroy event in GtkWindow
- replaced icon_size for pixel_size where used
it's also deprecated as seen in commit [3]
- use sugar_theme in all examples; set it manually not by just
importing common module
- fixed GtkBox.pack_start arguments
- flake/pep8 fixes

[1] https://developer.gnome.org/gtk3/stable/GtkHBox.html
[2] https://developer.gnome.org/gtk3/stable/GtkVBox.html
[3] 5802d67ee107ef82963770257071a779c4741a21