### PR TITLE
Added the missing get_locale_path() function from gtk2 version

### DIFF
--- a/src/sugar3/activity/i18n.py
+++ b/src/sugar3/activity/i18n.py
@@ -18,7 +18,11 @@
 # Boston, MA 02111-1307, USA.
 
 from gettext import gettext
+import locale
+import os
 import struct
+import sys
+
 
 import dateutil.parser
 import time
@@ -105,3 +109,45 @@ def pgettext(context, message):
     if '\x04' in translation:
         return message
     return translation
+    
+def get_locale_path(bundle_id):
+    """ Returns the locale path, which is the directory where the preferred
+        MO file is located.
+        The preferred MO file is the one with the latest translation.
+        @type   bundle_id:      string
+        @param  bundle_id:      The bundle id of the activity in question
+        @rtype:                 string
+        @return:                the preferred locale path
+    """
+
+    # Note: We pre-assign weights to the directories so that if no translations
+    # exist, the appropriate fallbacks (eg: bn for bn_BD) can be loaded
+    # The directory with the highest weight is returned, and if a MO file is
+    # found, the weight of the directory is set to the MO's modification time
+    # (as described in the MO header, and _not_ the filesystem mtime)
+
+    candidate_dirs = {}
+
+    if 'SUGAR_LOCALEDIR' in os.environ:
+        candidate_dirs[os.environ['SUGAR_LOCALEDIR']] = 2
+
+    candidate_dirs[os.path.join(sys.prefix, 'share', 'locale')] = 0
+
+    for candidate_dir in candidate_dirs.keys():
+        if os.path.exists(candidate_dir):
+            full_path = os.path.join(candidate_dir, \
+                locale.getdefaultlocale()[0], 'LC_MESSAGES', \
+                bundle_id + '.mo')
+            if os.path.exists(full_path):
+                try:
+                    candidate_dirs[candidate_dir] = \
+                        _extract_modification_time(full_path)
+                except (IOError, ValueError):
+                    # The mo file is damaged or has not been initialized
+                    # Set lowest priority
+                    candidate_dirs[candidate_dir] = -1
+
+    available_paths = sorted(candidate_dirs.iteritems(), key=lambda (k, v): \
+        (v, k), reverse=True)
+    preferred_path = available_paths[0][0]
+return preferred_path


### PR DESCRIPTION
The sugar3.activity.i18n module is missing the get_locale_path() function present in sugar.activity.i18n.