### PR TITLE
Prepend instead of append to path

### DIFF
--- a/bin/sugar-activity
+++ b/bin/sugar-activity
@@ -114,7 +114,7 @@ def main():
     os.environ['SUGAR_BUNDLE_PATH'] = os.path.abspath(os.curdir)
 
     bundle_path = os.environ['SUGAR_BUNDLE_PATH']
-    sys.path.append(bundle_path)
+    sys.path.insert(0, bundle_path)
 
     try:
         bundle = ActivityBundle(bundle_path)


### PR DESCRIPTION
When an activity is launched, an import should first search the activity bundle source rather than `/usr/bin`.

Fixes the need to change activity sources every time a system package conflicts with an import.

May impact any activity that relies on a system package being in search path before the bundle source.  Forty activities were tested, and none relied on this.

See also https://github.com/sugarlabs/Pippy/pull/45

CC @icarito.