### PR TITLE
Fix: #375 Pressing Enter during title editing saves the title

### DIFF
--- a/src/sugar3/activity/widgets.py
+++ b/src/sugar3/activity/widgets.py
@@ -177,12 +177,19 @@ class TitleEntry(Gtk.ToolItem):
         self.entry.set_text(activity.metadata['title'])
         self.entry.connect(
             'focus-out-event', self.__title_changed_cb, activity)
+        self.entry.connect('activate', self.__on_activate, activity)
         self.entry.connect('button-press-event', self.__button_press_event_cb)
         self.entry.show()
         self.add(self.entry)
 
         activity.metadata.connect('updated', self.__jobject_updated_cb)
         activity.connect('_closing', self.__closing_cb)
+
+    def __on_activate(self, widget, activity):
+        self.save_title(activity)
+        self.entry.hide()
+        self.entry.show()
+        return False
 
     def modify_bg(self, state, color):
         Gtk.ToolItem.modify_bg(self, state, color)


### PR DESCRIPTION
**Fixed in this PR:** #375 sugar3.activity.widgets.TitleEntry ignores enter key
**Fix**: Connected Key-Press event to a function which saves the title on detecting `enter`

**Tested on:** Packaged environment (using rdesktop) on Ubuntu 16.04
**Activities on which tested:**
 - Log
 - Pippy
 - Browse
 - Chat

@quozl kindly review.
 Also, please point my mistakes in commit/PR style, if any.

**Note**: I don't have line:89 in my version of sucrose. 
              Activities fail to load on adding it, Err: No `add_stop_button` function in activity. 
              Works fine without that line