### PR TITLE
Fix: #366 sugar3.graphics.alert.TimeoutAlert does not expose timeout condition 

### DIFF
--- a/examples/alert.py
+++ b/examples/alert.py
@@ -1,25 +1,33 @@
 from gi.repository import Gtk
 from sugar3.graphics.alert import TimeoutAlert
 from common import set_theme
+
+
 set_theme()
-
-
-def __start_response_cb(widget, data=None):
-    print 'Response: start download'
-
-
 w = Gtk.Window()
 w.connect("delete-event", Gtk.main_quit)
-
 box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 w.add(box)
 
-alert = TimeoutAlert(9)
-alert.props.title = 'Download started'
-alert.props.msg = 'Sugar'
+# Create a TimeoutAlert Object
+alert = TimeoutAlert(5)
+alert.props.title = '<Alert Title>'
+alert.props.msg = '<Alert Message>'
+
+# Add Timeout Object to the box
 box.pack_start(alert, False, False, 0)
-alert.connect('response', __start_response_cb)
 
+
+# Called when an alert object throws a response event.
+def __alert_response_cb(alert, response_id):
+    if response_id is Gtk.ResponseType.OK:
+        print 'Continue Button was clicked.'
+    elif response_id is Gtk.ResponseType.CANCEL:
+        print 'Cancel Button was clicked.'
+    elif response_id == -1:
+        print 'Timeout occurred'
+
+
+alert.connect('response', __alert_response_cb)
 w.show_all()
-
 Gtk.main()

--- a/src/sugar3/graphics/alert.py
+++ b/src/sugar3/graphics/alert.py
@@ -406,7 +406,7 @@ class _TimeoutAlert(Alert):
         self._timeout -= 1
         self._timeout_text.set_text(self._timeout)
         if self._timeout == 0:
-            Alert._response(self, Gtk.ResponseType.OK)
+            Alert._response(self, -1)
             return False
         return True
 


### PR DESCRIPTION
**Effect of this PR:**
 - `_TimeoutAlert` returns a response ID of -1 on timeout
 - Checked for activities using this response via [this](https://github.com/search?q=org%3Asugarlabs+TimeoutAlert&type=Code). Turns out none of the activities use the response emitted on timeout.

@quozl Kindly review