### PR TITLE
Fix: #378 Issue non-fatal warnings on missing metadata

### DIFF
--- a/src/sugar3/activity/bundlebuilder.py
+++ b/src/sugar3/activity/bundlebuilder.py
@@ -237,6 +237,7 @@ class XOPackager(Packager):
     def __init__(self, builder):
         Packager.__init__(self, builder.config)
 
+        self.metadata_keys = ['activity_version', 'license']
         self.builder = builder
         self.builder.build_locale()
         self.package_path = os.path.join(self.config.dist_dir,
@@ -245,7 +246,7 @@ class XOPackager(Packager):
     def package(self):
         bundle_zip = zipfile.ZipFile(self.package_path, 'w',
                                      zipfile.ZIP_DEFLATED)
-
+        self.metadata_warn()
         for f in self.get_files_in_git():
             bundle_zip.write(os.path.join(self.config.source_dir, f),
                              os.path.join(self.config.bundle_root_dir, f))
@@ -256,6 +257,16 @@ class XOPackager(Packager):
                                           'locale', f))
 
         bundle_zip.close()
+
+    def metadata_warn(self):
+        with open(os.path.join(self.config.source_dir, 'activity','activity.info')) as f:
+            activity_metadata = f.readlines()
+        for key in self.metadata_keys:
+            for metadata in activity_metadata:
+                if metadata.startswith(key):
+                    break
+            else:
+                logging.warning('"' + key + '"' + ' key is missing in activity.info')
 
 
 class SourcePackager(Packager):

--- a/src/sugar3/activity/bundlebuilder.py
+++ b/src/sugar3/activity/bundlebuilder.py
@@ -237,7 +237,6 @@ class XOPackager(Packager):
     def __init__(self, builder):
         Packager.__init__(self, builder.config)
 
-        self.metadata_keys = ['activity_version', 'license']
         self.builder = builder
         self.builder.build_locale()
         self.package_path = os.path.join(self.config.dist_dir,
@@ -246,7 +245,7 @@ class XOPackager(Packager):
     def package(self):
         bundle_zip = zipfile.ZipFile(self.package_path, 'w',
                                      zipfile.ZIP_DEFLATED)
-        self.metadata_warn()
+
         for f in self.get_files_in_git():
             bundle_zip.write(os.path.join(self.config.source_dir, f),
                              os.path.join(self.config.bundle_root_dir, f))
@@ -257,16 +256,6 @@ class XOPackager(Packager):
                                           'locale', f))
 
         bundle_zip.close()
-
-    def metadata_warn(self):
-        with open(os.path.join(self.config.source_dir, 'activity','activity.info')) as f:
-            activity_metadata = f.readlines()
-        for key in self.metadata_keys:
-            for metadata in activity_metadata:
-                if metadata.startswith(key):
-                    break
-            else:
-                logging.warning('"' + key + '"' + ' key is missing in activity.info')
 
 
 class SourcePackager(Packager):

--- a/src/sugar3/bundle/activitybundle.py
+++ b/src/sugar3/bundle/activitybundle.py
@@ -133,7 +133,10 @@ class ActivityBundle(Bundle):
 
         section = 'Activity'
 
-        self.metadata_warn(cp, section)
+        for tag in ['activity_version', 'license', 'icon']:
+            if not cp.has_option(section, tag):
+                logging.warning('activity.info does not have the tag "' + tag + '"')
+
         if cp.has_option(section, 'bundle_id'):
             self._bundle_id = cp.get(section, 'bundle_id')
         else:
@@ -211,19 +214,6 @@ class ActivityBundle(Bundle):
                 raise MalformedBundleException(
                     'Activity bundle %s has invalid max_participants %s' %
                     (self.get_path(), max_participants))
-
-    def metadata_warn(self, options, section):
-        keys = {
-            'Activity': ['name', 'activity_version',
-                         'bundle_id', 'license', 'icon'
-                         'exec'],
-            'Appstream': ['metadata_license', 'description']
-        }
-        for types, tags in keys.items():
-            for tag in tags:
-                if not options.has_option(section, tag):
-                    logging.warning('activity.info doesn\'t have the tag "' +
-                                    tag + '", necessary for ' + types)
 
     def _get_linfo_file(self):
         # Using method from gettext.py, first find languages from environ

--- a/src/sugar3/bundle/activitybundle.py
+++ b/src/sugar3/bundle/activitybundle.py
@@ -135,7 +135,7 @@ class ActivityBundle(Bundle):
 
         for tag in ['activity_version', 'license', 'icon']:
             if not cp.has_option(section, tag):
-                logging.warning('activity.info does not have the tag "' + tag + '"')
+                logging.warning('Activity bundle does not specify a %s' % tag)
 
         if cp.has_option(section, 'bundle_id'):
             self._bundle_id = cp.get(section, 'bundle_id')

--- a/src/sugar3/bundle/activitybundle.py
+++ b/src/sugar3/bundle/activitybundle.py
@@ -133,6 +133,7 @@ class ActivityBundle(Bundle):
 
         section = 'Activity'
 
+        self.metadata_warn(cp, section)
         if cp.has_option(section, 'bundle_id'):
             self._bundle_id = cp.get(section, 'bundle_id')
         else:
@@ -210,6 +211,18 @@ class ActivityBundle(Bundle):
                 raise MalformedBundleException(
                     'Activity bundle %s has invalid max_participants %s' %
                     (self.get_path(), max_participants))
+
+    def metadata_warn(self, options, section):
+        keys = {
+            'Activity': ['name', 'activity_version',
+                         'bundle_id', 'license', 'icon'
+                         'exec'],
+            'Appstream': ['metadata_license', 'description']
+        }
+        for types, tags in keys.items():
+            for tag in tags:
+                if not options.has_option(section, tag):
+                    logging.warning('activity.info doesn\'t have the tag "' + tag + '", necessary for ' + types)
 
     def _get_linfo_file(self):
         # Using method from gettext.py, first find languages from environ

--- a/src/sugar3/bundle/activitybundle.py
+++ b/src/sugar3/bundle/activitybundle.py
@@ -222,7 +222,8 @@ class ActivityBundle(Bundle):
         for types, tags in keys.items():
             for tag in tags:
                 if not options.has_option(section, tag):
-                    logging.warning('activity.info doesn\'t have the tag "' + tag + '", necessary for ' + types)
+                    logging.warning('activity.info doesn\'t have the tag "' +
+                                    tag + '", necessary for ' + types)
 
     def _get_linfo_file(self):
         # Using method from gettext.py, first find languages from environ


### PR DESCRIPTION
**Fixed in this PR:** #378
**Changes made:**  
 - `python setup.py dist_xo` will now issue warnings(non-fatal), if `activity.info` won't have `license` or `activity_version` tags
 - `name` tag already issued a fatal error, if missing and hence was excluded.

**Suggestion:**
All tags independent of whether they are necessary for `aslo` should issue a warning. Kindly let me know, I will update the PR

**Tested**