### PR TITLE
[Fix]: #375 (sugar3.activity.widgets.TitleEntry ignores enter key)

### DIFF
--- a/src/sugar3/activity/widgets.py
+++ b/src/sugar3/activity/widgets.py
@@ -19,6 +19,7 @@
 
 from gi.repository import Gdk
 from gi.repository import Gtk
+from gi.repository import GObject
 import gettext
 
 from sugar3.graphics.toolbutton import ToolButton
@@ -71,6 +72,7 @@ class ActivityToolbarButton(ToolbarButton):
 
     def __init__(self, activity, **kwargs):
         toolbar = ActivityToolbar(activity, orientation_left=True)
+        toolbar.connect('entered', lambda widget: self.emit('clicked'))
 
         ToolbarButton.__init__(self, page=toolbar, **kwargs)
 
@@ -167,6 +169,9 @@ class ShareButton(RadioMenuButton):
 
 
 class TitleEntry(Gtk.ToolItem):
+    __gsignals__ = {
+        'entered': (GObject.SignalFlags.RUN_FIRST, None, ([])),
+    }
 
     def __init__(self, activity, **kwargs):
         Gtk.ToolItem.__init__(self)
@@ -190,6 +195,7 @@ class TitleEntry(Gtk.ToolItem):
         entry.select_region(0, 0)
         entry.hide()
         entry.show()
+        self.emit('entered')
         return False
 
     def modify_bg(self, state, color):
@@ -320,6 +326,9 @@ class DescriptionItem(ToolButton):
 
 class ActivityToolbar(Gtk.Toolbar):
     """The Activity toolbar with the Journal entry title and sharing button"""
+    __gsignals__ = {
+        'entered': (GObject.SignalFlags.RUN_FIRST, None, ([])),
+    }
 
     def __init__(self, activity, orientation_left=False):
         Gtk.Toolbar.__init__(self)
@@ -328,6 +337,7 @@ class ActivityToolbar(Gtk.Toolbar):
 
         if activity.metadata:
             title_button = TitleEntry(activity)
+            title_button.connect('entered', lambda widget: self.emit('entered'))
             title_button.show()
             self.insert(title_button, -1)
             self.title = title_button.entry

--- a/src/sugar3/activity/widgets.py
+++ b/src/sugar3/activity/widgets.py
@@ -72,7 +72,7 @@ class ActivityToolbarButton(ToolbarButton):
 
     def __init__(self, activity, **kwargs):
         toolbar = ActivityToolbar(activity, orientation_left=True)
-        toolbar.connect('entered', lambda widget: self.emit('clicked'))
+        toolbar.connect('enter-key-press', lambda widget: self.emit('clicked'))
 
         ToolbarButton.__init__(self, page=toolbar, **kwargs)
 
@@ -170,7 +170,7 @@ class ShareButton(RadioMenuButton):
 
 class TitleEntry(Gtk.ToolItem):
     __gsignals__ = {
-        'entered': (GObject.SignalFlags.RUN_FIRST, None, ([])),
+        'enter-key-press': (GObject.SignalFlags.RUN_FIRST, None, ([])),
     }
 
     def __init__(self, activity, **kwargs):
@@ -195,7 +195,7 @@ class TitleEntry(Gtk.ToolItem):
         entry.select_region(0, 0)
         entry.hide()
         entry.show()
-        self.emit('entered')
+        self.emit('enter-key-press')
         return False
 
     def modify_bg(self, state, color):
@@ -327,7 +327,7 @@ class DescriptionItem(ToolButton):
 class ActivityToolbar(Gtk.Toolbar):
     """The Activity toolbar with the Journal entry title and sharing button"""
     __gsignals__ = {
-        'entered': (GObject.SignalFlags.RUN_FIRST, None, ([])),
+        'enter-key-press': (GObject.SignalFlags.RUN_FIRST, None, ([])),
     }
 
     def __init__(self, activity, orientation_left=False):
@@ -337,7 +337,7 @@ class ActivityToolbar(Gtk.Toolbar):
 
         if activity.metadata:
             title_button = TitleEntry(activity)
-            title_button.connect('entered', lambda widget: self.emit('entered'))
+            title_button.connect('enter-key-press', lambda widget: self.emit('enter-key-press'))
             title_button.show()
             self.insert(title_button, -1)
             self.title = title_button.entry


### PR DESCRIPTION
**Fixed in this PR:** #375 
- [X] `enter` key should dismiss the dialog on activities that use one (most of them except Chat),
- [x] test with or without the save-as feature,
- [ ] backport to https://github.com/sugarlabs/sugar-toolkit.

**Note:** This is an in progress PR

**Tested on:**
Sugar 0.112, Ubuntu 16.04

@quozl Kindly review