### PR TITLE
sugar3.speech - remove GConf compatibility

### DIFF
--- a/src/sugar3/speech.py
+++ b/src/sugar3/speech.py
@@ -288,11 +288,6 @@ class SpeechManager(GObject.GObject):
 
     def save(self):
         self._save_timeout_id = -1
-        # DEPRECATED
-        from gi.repository import GConf
-        client = GConf.Client.get_default()
-        client.set_int('/desktop/sugar/speech/pitch', self._pitch)
-        client.set_int('/desktop/sugar/speech/rate', self._rate)
 
         settings = Gio.Settings('org.sugarlabs.speech')
         settings.set_int('pitch', self._pitch)


### PR DESCRIPTION
GConf compatibility support in sugar3.speech module allows activities to read or be notified of changes to the speech pitch and rate.  GConf is deprecated.

Remove GConf from the sugar3.speech module.

The speech pitch and rate will no longer be available via GConf.  Fix GTK+ 2 activities by porting to GTK+ 3.  Fix GTK+ 3 activities by porting from GConf to Gio.Settings.

Tested on Ubuntu 16.04.