### PR TITLE
Remove unwanted dependency of toolkit to jarabe

### DIFF
--- a/examples/popwindow.py
+++ b/examples/popwindow.py
@@ -1,0 +1,16 @@
+from sugar3.graphics.popwindow import PopWindow
+
+import common
+test = common.Test()
+
+
+def popwindow_closed(widget):
+    print("Popwindow closed")
+
+
+c = PopWindow()
+c.connect('destroy', popwindow_closed)
+c.show_all()  # Press `escape` key or click on the close_button to close the popwindow
+
+if __name__ == '__main__':
+    common.main(test)

--- a/src/sugar3/graphics/popwindow.py
+++ b/src/sugar3/graphics/popwindow.py
@@ -35,8 +35,6 @@ from gi.repository import GObject
 from sugar3.graphics import style
 from sugar3.graphics.toolbutton import ToolButton
 
-from jarabe.model import shell
-
 
 class PopWindow(Gtk.Window):
     """
@@ -70,7 +68,6 @@ class PopWindow(Gtk.Window):
 
         self.connect('realize', self.__realize_cb)
         self.connect('key-press-event', self.__key_press_event_cb)
-        self.connect('hide', self.__hide_cb)
 
         self._vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.add(self._vbox)
@@ -135,10 +132,6 @@ class PopWindow(Gtk.Window):
             parent = GdkX11.X11Window.foreign_new_for_display(
                 display, self._parent_window_xid)
             window.set_transient_for(parent)
-            shell.get_model().push_modal()
-
-    def __hide_cb(self, widget):
-        shell.get_model().pop_modal()
 
     def add_view(self, widget, expand=True, fill=True, padding=0):
         '''


### PR DESCRIPTION
 - Add exmaple demonstrating `sugar3.graphics.popwindow.PopWindow`
 - Remove dependancy of `sugar3.graohics.popwindow` to `jarabe`