### PR TITLE
Remove example unrelated to Sugar Toolkit

### DIFF
--- a/examples/intro.py
+++ b/examples/intro.py
@@ -1,8 +1,0 @@
-from gi.repository import Gtk
-from common import set_theme
-from jarabe.intro.window import IntroWindow
-
-set_theme()
-win = IntroWindow()
-win.show_all()
-Gtk.main()


### PR DESCRIPTION
Example demonstrates `jarabe.intro.window.IntroWindow` and is unrelated to `Sugar toolkit`.
Hence, it can be removed from the toolkit

