### PR TITLE
Fix traceback when an icon name matches a GNOME theme icon

### DIFF
--- a/src/sugar3/graphics/icon.py
+++ b/src/sugar3/graphics/icon.py
@@ -205,7 +205,9 @@ class _IconBuffer(object):
         elif info.get_filename():
             # try read from the .icon file
             icon_filename = info.get_filename().replace('.svg', '.icon')
-            if os.path.exists(icon_filename):
+            if icon_filename != info.get_filename() and \
+                os.path.exists(icon_filename):
+
                 try:
                     with open(icon_filename) as config_file:
                         cp = ConfigParser()


### PR DESCRIPTION
When an icon file name matches a GNOME theme icon;

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/sugar3/graphics/icon.py", line 214, in _get_attach_points
    cp.readfp(config_file)
  File "/usr/lib/python2.7/ConfigParser.py", line 324, in readfp
    self._read(fp, filename)
  File "/usr/lib/python2.7/ConfigParser.py", line 512, in _read
    raise MissingSectionHeaderError(fpname, lineno, line)
MissingSectionHeaderError: File contains no section headers.
```

Caused by reading a .png file as if it were config file, in turn because the icon was expected by the toolkit to be .svg file type.

Regression introduced by f796638.

Fixes https://github.com/sugarlabs/activity-abacus/issues/16