### PR TITLE
use sugar-activity-build in favor or adding setup.py to every activity

### DIFF
--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -1,1 +1,1 @@
-dist_bin_SCRIPTS = sugar-activity sugar-activity-web
+dist_bin_SCRIPTS = sugar-activity sugar-activity-web sugar-activity-build

--- a/bin/sugar-activity-build
+++ b/bin/sugar-activity-build
@@ -1,0 +1,5 @@
+#!/usr/bin/env python2
+
+from sugar3.activity import bundlebuilder
+
+bundlebuilder.start()

--- a/src/sugar3/activity/bundlebuilder.py
+++ b/src/sugar3/activity/bundlebuilder.py
@@ -622,7 +622,7 @@ def start():
 
     options = parser.parse_args()
 
-    source_dir = os.path.abspath(os.path.dirname(sys.argv[0]))
+    source_dir = os.path.abspath(os.path.dirname(os.curdir))
     config = Config(source_dir)
 
     try:


### PR DESCRIPTION
Instead of using
```python
./setup.py dist_xo
```
we would have to use
```python
sugar-activity-build dist_xo
```

@quozl @walterbender should this change be included ?

reasons for proposed change - better than the alternate of having same `setup.py` in each activity.