### PR TITLE
[In Progress] Port to TelepathyGLib

### DIFF
--- a/src/sugar3/activity/activity.py
+++ b/src/sugar3/activity/activity.py
@@ -172,22 +172,18 @@ import json
 import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gdk', '3.0')
+gi.require_version('TelepathyGLib', '0.12')
 gi.require_version('SugarExt', '1.0')
 
 from gi.repository import GLib
 from gi.repository import GObject
 from gi.repository import Gdk
 from gi.repository import Gtk
+from gi.repository import TelepathyGLib
 import dbus
 import dbus.service
 from dbus import PROPERTIES_IFACE
 from telepathy.server import DBusProperties
-from telepathy.interfaces import CHANNEL, \
-    CHANNEL_TYPE_TEXT, \
-    CLIENT, \
-    CLIENT_HANDLER
-from telepathy.constants import CONNECTION_HANDLE_TYPE_CONTACT
-from telepathy.constants import CONNECTION_HANDLE_TYPE_ROOM
 
 from sugar3 import util
 from sugar3 import power
@@ -531,11 +527,11 @@ class Activity(Window, Gtk.Container):
         logging.debug('Activity.__got_channel_cb')
         pservice = presenceservice.get_instance()
 
-        if handle_type == CONNECTION_HANDLE_TYPE_ROOM:
+        if handle_type == TelepathyGLib.HandleType.ROOM:
             connection_name = connection_path.replace('/', '.')[1:]
             bus = dbus.SessionBus()
             channel = bus.get_object(connection_name, channel_path)
-            room_handle = channel.Get(CHANNEL, 'TargetHandle')
+            room_handle = channel.Get(TelepathyGLib.IFACE_CHANNEL, 'TargetHandle')
             mesh_instance = pservice.get_activity_by_handle(connection_path,
                                                             room_handle)
         else:
@@ -1418,36 +1414,36 @@ class Activity(Window, Gtk.Container):
 
 class _ClientHandler(dbus.service.Object, DBusProperties):
     def __init__(self, bundle_id, got_channel_cb):
-        self._interfaces = set([CLIENT, CLIENT_HANDLER, PROPERTIES_IFACE])
+        self._interfaces = set([TelepathyGLib.IFACE_CLIENT, TelepathyGLib.IFACE_CLIENT_HANDLER, PROPERTIES_IFACE])
         self._got_channel_cb = got_channel_cb
 
         bus = dbus.Bus()
-        name = CLIENT + '.' + bundle_id
+        name = TelepathyGLib.IFACE_CLIENT + '.' + bundle_id
         bus_name = dbus.service.BusName(name, bus=bus)
 
         path = '/' + name.replace('.', '/')
         dbus.service.Object.__init__(self, bus_name, path)
         DBusProperties.__init__(self)
 
-        self._implement_property_get(CLIENT, {
+        self._implement_property_get(TelepathyGLib.IFACE_CLIENT, {
             'Interfaces': lambda: list(self._interfaces),
         })
-        self._implement_property_get(CLIENT_HANDLER, {
+        self._implement_property_get(TelepathyGLib.IFACE_CLIENT_HANDLER, {
             'HandlerChannelFilter': self.__get_filters_cb,
         })
 
     def __get_filters_cb(self):
         logging.debug('__get_filters_cb')
         filters = {
-            CHANNEL + '.ChannelType': CHANNEL_TYPE_TEXT,
-            CHANNEL + '.TargetHandleType': CONNECTION_HANDLE_TYPE_CONTACT,
+            TelepathyGLib.IFACE_CHANNEL + '.ChannelType': TelepathyGLib.IFACE_CHANNEL_TYPE_TEXT,
+            TelepathyGLib.IFACE_CHANNEL + '.TargetHandleType': TelepathyGLib.HandleType.CONTACT,
         }
         filter_dict = dbus.Dictionary(filters, signature='sv')
         logging.debug('__get_filters_cb %r' % dbus.Array([filter_dict],
                       signature='a{sv}'))
         return dbus.Array([filter_dict], signature='a{sv}')
 
-    @dbus.service.method(dbus_interface=CLIENT_HANDLER,
+    @dbus.service.method(dbus_interface=TelepathyGLib.IFACE_CLIENT_HANDLER,
                          in_signature='ooa(oa{sv})aota{sv}', out_signature='')
     def HandleChannels(self, account, connection, channels, requests_satisfied,
                        user_action_time, handler_info):
@@ -1456,9 +1452,9 @@ class _ClientHandler(dbus.service.Object, DBusProperties):
                           user_action_time, handler_info))
         try:
             for object_path, properties in channels:
-                channel_type = properties[CHANNEL + '.ChannelType']
-                handle_type = properties[CHANNEL + '.TargetHandleType']
-                if channel_type == CHANNEL_TYPE_TEXT:
+                channel_type = properties[TelepathyGLib.IFACE_CHANNEL + '.ChannelType']
+                handle_type = properties[TelepathyGLib.IFACE_CHANNEL + '.TargetHandleType']
+                if channel_type == TelepathyGLib.IFACE_CHANNEL_TYPE_TEXT:
                     self._got_channel_cb(connection, object_path, handle_type)
         except Exception, e:
             logging.exception(e)

--- a/src/sugar3/presence/activity.py
+++ b/src/sugar3/presence/activity.py
@@ -28,6 +28,7 @@ import dbus
 from dbus import PROPERTIES_IFACE
 from gi.repository import GObject
 from gi.repository import TelepathyGLib
+from telepathy.client import Channel
 
 from sugar3.presence.buddy import Buddy
 
@@ -574,11 +575,11 @@ class _JoinCommand(_BaseCommand):
             dbus_interface=TelepathyGLib.IFACE_CONNECTION)
 
     def __create_text_channel_cb(self, channel_path):
-        TelepathyGLib.Channel(self._connection.requested_bus_name, channel_path,
+        Channel(self._connection.requested_bus_name, channel_path,
                 ready_handler=self.__text_channel_ready_cb)
 
     def __create_tubes_channel_cb(self, channel_path):
-        TelepathyGLib.Channel(self._connection.requested_bus_name, channel_path,
+        Channel(self._connection.requested_bus_name, channel_path,
                 ready_handler=self.__tubes_channel_ready_cb)
 
     def __tubes_error_handler_cb(self, error):

--- a/src/sugar3/presence/activity.py
+++ b/src/sugar3/presence/activity.py
@@ -27,24 +27,12 @@ from functools import partial
 import dbus
 from dbus import PROPERTIES_IFACE
 from gi.repository import GObject
-from telepathy.client import Channel
-from telepathy.interfaces import CHANNEL, \
-    CHANNEL_INTERFACE_GROUP, \
-    CHANNEL_TYPE_TUBES, \
-    CHANNEL_TYPE_TEXT, \
-    CONNECTION, \
-    PROPERTIES_INTERFACE
-from telepathy.constants import CHANNEL_GROUP_FLAG_CHANNEL_SPECIFIC_HANDLES, \
-    HANDLE_TYPE_ROOM, \
-    HANDLE_TYPE_CONTACT, \
-    PROPERTY_FLAG_WRITE
+from gi.repository import TelepathyGLib
 
 from sugar3.presence.buddy import Buddy
 
 CONN_INTERFACE_ACTIVITY_PROPERTIES = 'org.laptop.Telepathy.ActivityProperties'
 CONN_INTERFACE_BUDDY_INFO = 'org.laptop.Telepathy.BuddyInfo'
-CONN_INTERFACE_ROOM_CONFIG = \
-    'org.freedesktop.Telepathy.Channel.Interface.RoomConfig1'
 
 _logger = logging.getLogger('sugar3.presence.activity')
 
@@ -237,7 +225,7 @@ class Activity(GObject.GObject):
         return self._joined_buddies.values()
 
     def get_buddy_by_handle(self, handle):
-        """Retrieve the Buddy object given a telepathy handle.
+        """Retrieve the Buddy object given a TelepathyGLib handle.
 
         buddy object paths are cached in self._handle_to_buddy_path,
         so we can get the buddy without calling PS.
@@ -259,7 +247,7 @@ class Activity(GObject.GObject):
                                'not shared.')
         self.telepathy_text_chan.AddMembers(
             [buddy.contact_handle], message,
-            dbus_interface=CHANNEL_INTERFACE_GROUP,
+            dbus_interface=TelepathyGLib.IFACE_CHANNEL_INTERFACE_GROUP,
             reply_handler=partial(
                 self.__invite_cb, response_cb),
             error_handler=partial(self.__invite_cb, response_cb))
@@ -282,7 +270,7 @@ class Activity(GObject.GObject):
         self._start_tracking_channel()
 
     def _start_tracking_buddies(self):
-        group = self.telepathy_text_chan[CHANNEL_INTERFACE_GROUP]
+        group = self.telepathy_text_chan[TelepathyGLib.IFACE_CHANNEL_INTERFACE_GROUP]
 
         group.GetAllMembers(reply_handler=self.__get_all_members_cb,
                             error_handler=self.__error_handler_cb)
@@ -291,7 +279,7 @@ class Activity(GObject.GObject):
                                 self.__text_channel_members_changed_cb)
 
     def _start_tracking_channel(self):
-        channel = self.telepathy_text_chan[CHANNEL]
+        channel = self.telepathy_text_chan[TelepathyGLib.IFACE_CHANNEL]
         channel.connect_to_signal('Closed', self.__text_channel_closed_cb)
 
     def __get_all_members_cb(self, members, local_pending, remote_pending):
@@ -308,15 +296,15 @@ class Activity(GObject.GObject):
     def _resolve_handles(self, input_handles, reply_cb):
         def get_handle_owners_cb(handles):
             self.telepathy_conn.InspectHandles(
-                HANDLE_TYPE_CONTACT, handles,
+                TelepathyGLib.HandleType.CONTACT, handles,
                 reply_handler=reply_cb,
                 error_handler=self.__error_handler_cb,
-                dbus_interface=CONNECTION)
+                dbus_interface=TelepathyGLib.IFACE_CONNECTION)
 
         if self._text_channel_group_flags & \
-                CHANNEL_GROUP_FLAG_CHANNEL_SPECIFIC_HANDLES:
+                TelepathyGLib.ChannelGroupFlags.CHANNEL_SPECIFIC_HANDLES:
 
-            group = self.telepathy_text_chan[CHANNEL_INTERFACE_GROUP]
+            group = self.telepathy_text_chan[TelepathyGLib.IFACE_CHANNEL_INTERFACE_GROUP]
             group.GetHandleOwners(input_handles,
                                   reply_handler=get_handle_owners_cb,
                                   error_handler=self.__error_handler_cb)
@@ -504,11 +492,11 @@ class _ShareCommand(_BaseCommand):
 
     def run(self):
         self._connection.RequestHandles(
-            HANDLE_TYPE_ROOM,
+            TelepathyGLib.HandleType.ROOM,
             [self._activity_id],
             reply_handler=self.__got_handles_cb,
             error_handler=self.__error_handler_cb,
-            dbus_interface=CONNECTION)
+            dbus_interface=TelepathyGLib.IFACE_CONNECTION)
 
     def __got_handles_cb(self, handles):
         logging.debug('__got_handles_cb %r' % handles)
@@ -560,7 +548,7 @@ class _JoinCommand(_BaseCommand):
         if self._finished:
             raise RuntimeError('This command has already finished')
 
-        self._connection.Get(CONNECTION, 'SelfHandle',
+        self._connection.Get(TelepathyGLib.IFACE_CONNECTION, 'SelfHandle',
                              reply_handler=self.__get_self_handle_cb,
                              error_handler=self.__error_handler_cb,
                              dbus_interface=PROPERTIES_IFACE)
@@ -569,28 +557,28 @@ class _JoinCommand(_BaseCommand):
         self._global_self_handle = handle
 
         self._connection.RequestChannel(
-            CHANNEL_TYPE_TEXT,
-            HANDLE_TYPE_ROOM,
+            TelepathyGLib.IFACE_CHANNEL_TYPE_TEXT,
+            TelepathyGLib.HandleType.ROOM,
             self.room_handle, True,
             reply_handler=self.__create_text_channel_cb,
             error_handler=self.__error_handler_cb,
-            dbus_interface=CONNECTION)
+            dbus_interface=TelepathyGLib.IFACE_CONNECTION)
 
         self._connection.RequestChannel(
-            CHANNEL_TYPE_TUBES,
-            HANDLE_TYPE_ROOM,
+            TelepathyGLib.IFACE_CHANNEL_TYPE_TUBES,
+            TelepathyGLib.HandleType.ROOM,
             self.room_handle,
             True,
             reply_handler=self.__create_tubes_channel_cb,
             error_handler=self.__tubes_error_handler_cb,
-            dbus_interface=CONNECTION)
+            dbus_interface=TelepathyGLib.IFACE_CONNECTION)
 
     def __create_text_channel_cb(self, channel_path):
-        Channel(self._connection.requested_bus_name, channel_path,
+        TelepathyGLib.Channel(self._connection.requested_bus_name, channel_path,
                 ready_handler=self.__text_channel_ready_cb)
 
     def __create_tubes_channel_cb(self, channel_path):
-        Channel(self._connection.requested_bus_name, channel_path,
+        TelepathyGLib.Channel(self._connection.requested_bus_name, channel_path,
                 ready_handler=self.__tubes_channel_ready_cb)
 
     def __tubes_error_handler_cb(self, error):
@@ -635,7 +623,7 @@ class _JoinCommand(_BaseCommand):
         # FIXME: cope with non-Group channels here if we want to support
         # non-OLPC-compatible IMs
 
-        group = self.text_channel[CHANNEL_INTERFACE_GROUP]
+        group = self.text_channel[TelepathyGLib.IFACE_CHANNEL_INTERFACE_GROUP]
 
         def got_all_members(members, local_pending, remote_pending):
             _logger.debug('got_all_members members %r local_pending %r '
@@ -643,7 +631,7 @@ class _JoinCommand(_BaseCommand):
                                                  remote_pending))
 
             if self.text_channel_group_flags & \
-                    CHANNEL_GROUP_FLAG_CHANNEL_SPECIFIC_HANDLES:
+                    TelepathyGLib.ChannelGroupFlags.CHANNEL_SPECIFIC_HANDLES:
                 self_handle = self.channel_self_handle
             else:
                 self_handle = self._global_self_handle
@@ -689,7 +677,7 @@ class _JoinCommand(_BaseCommand):
                               self.channel_self_handle))
 
         if self.text_channel_group_flags & \
-                CHANNEL_GROUP_FLAG_CHANNEL_SPECIFIC_HANDLES:
+                TelepathyGLib.ChannelGroupFlags.CHANNEL_SPECIFIC_HANDLES:
             self_handle = self.channel_self_handle
         else:
             self_handle = self._global_self_handle
@@ -698,11 +686,11 @@ class _JoinCommand(_BaseCommand):
             return
 
         # Use RoomConfig1 to configure the text channel. If this
-        # doesn't exist, fall-back on old-style PROPERTIES_INTERFACE.
-        if CONN_INTERFACE_ROOM_CONFIG in self.text_channel:
+        # doesn't exist, fall-back on old-style IFACE_DBUS_PROPERTIES.
+        if TelepathyGLib.IFACE_CHANNEL_INTERFACE_ROOM_CONFIG in self.text_channel:
             self.__update_room_config()
-        elif PROPERTIES_INTERFACE in self.text_channel:
-            self.text_channel[PROPERTIES_INTERFACE].ListProperties(
+        elif TelepathyGLib.IFACE_DBUS_PROPERTIES in self.text_channel:
+            self.text_channel[TelepathyGLib.IFACE_DBUS_PROPERTIES].ListProperties(
                 reply_handler=self.__list_properties_cb,
                 error_handler=self.__error_handler_cb)
         else:
@@ -727,7 +715,7 @@ class _JoinCommand(_BaseCommand):
             # don't appear in server room lists
             'Private': True,
         }
-        room_cfg = self.text_channel[CONN_INTERFACE_ROOM_CONFIG]
+        room_cfg = self.text_channel[TelepathyGLib.IFACE_CHANNEL_INTERFACE_ROOM_CONFIG]
         room_cfg.UpdateConfiguration(props,
                                      reply_handler=self.__room_cfg_updated_cb,
                                      error_handler=self.__room_cfg_error_cb)
@@ -766,14 +754,14 @@ class _JoinCommand(_BaseCommand):
         for ident, name, sig_, flags in prop_specs:
             value = props.pop(name, None)
             if value is not None:
-                if flags & PROPERTY_FLAG_WRITE:
+                if flags & TelepathyGLib.PropertyFlags.WRITE:
                     props_to_set.append((ident, value))
                 # FIXME: else error, but only if we're creating the room?
         # FIXME: if props is nonempty, then we want to set props that aren't
         # supported here - raise an error?
 
         if props_to_set:
-            self.text_channel[PROPERTIES_INTERFACE].SetProperties(
+            self.text_channel[TelepathyGLib.IFACE_DBUS_PROPERTIES].SetProperties(
                 props_to_set, reply_handler=self.__set_properties_cb,
                 error_handler=self.__error_handler_cb)
         else:

--- a/src/sugar3/presence/buddy.py
+++ b/src/sugar3/presence/buddy.py
@@ -24,16 +24,12 @@ STABLE.
 import logging
 
 from gi.repository import GObject
+from gi.repository import TelepathyGLib
 import dbus
-from telepathy.interfaces import CONNECTION, \
-    CONNECTION_INTERFACE_ALIASING, \
-    CONNECTION_INTERFACE_CONTACTS
-from telepathy.constants import HANDLE_TYPE_CONTACT
 
 from sugar3.presence.connectionmanager import get_connection_manager
 from sugar3.profile import get_color, get_nick_name
 
-ACCOUNT_MANAGER_SERVICE = 'org.freedesktop.Telepathy.AccountManager'
 CONN_INTERFACE_BUDDY_INFO = 'org.laptop.Telepathy.BuddyInfo'
 
 _logger = logging.getLogger('sugar3.presence.buddy')
@@ -160,8 +156,8 @@ class Buddy(BaseBuddy):
 
         bus = dbus.SessionBus()
         obj = bus.get_object(connection_name, connection.object_path)
-        handles = obj.RequestHandles(HANDLE_TYPE_CONTACT, [self.contact_id],
-                                     dbus_interface=CONNECTION)
+        handles = obj.RequestHandles(TelepathyGLib.HandleType.CONTACT, [self.contact_id],
+                                     dbus_interface=TelepathyGLib.IFACE_CONNECTION)
         self.contact_handle = handles[0]
 
         self._get_properties_call = bus.call_async(
@@ -179,10 +175,10 @@ class Buddy(BaseBuddy):
         self._get_attributes_call = bus.call_async(
             connection_name,
             connection.object_path,
-            CONNECTION_INTERFACE_CONTACTS,
+            TelepathyGLib.IFACE_CONNECTION_INTERFACE_CONTACTS,
             'GetContactAttributes',
             'auasb',
-            ([self.contact_handle], [CONNECTION_INTERFACE_ALIASING],
+            ([self.contact_handle], [TelepathyGLib.IFACE_CONNECTION_INTERFACE_ALIASING],
              False),
             reply_handler=self.__got_attributes_cb,
             error_handler=self.__error_handler_cb)
@@ -219,7 +215,7 @@ class Buddy(BaseBuddy):
             self.props.tags = properties['tags']
 
     def _update_attributes(self, attributes):
-        nick_key = CONNECTION_INTERFACE_ALIASING + '/alias'
+        nick_key = TelepathyGLib.IFACE_CONNECTION_INTERFACE_ALIASING + '/alias'
         if nick_key in attributes:
             self.props.nick = attributes[nick_key]
 

--- a/src/sugar3/presence/presenceservice.py
+++ b/src/sugar3/presence/presenceservice.py
@@ -23,6 +23,7 @@ STABLE.
 import logging
 
 from gi.repository import GObject
+from gi.repository import TelepathyGLib
 import dbus
 import dbus.exceptions
 from dbus import PROPERTIES_IFACE
@@ -31,16 +32,8 @@ from sugar3.presence.buddy import Buddy, Owner
 from sugar3.presence.activity import Activity
 from sugar3.presence.connectionmanager import get_connection_manager
 
-from telepathy.interfaces import ACCOUNT, \
-    ACCOUNT_MANAGER, \
-    CONNECTION
-from telepathy.constants import HANDLE_TYPE_CONTACT
-
 
 _logger = logging.getLogger('sugar3.presence.presenceservice')
-
-ACCOUNT_MANAGER_SERVICE = 'org.freedesktop.Telepathy.AccountManager'
-ACCOUNT_MANAGER_PATH = '/org/freedesktop/Telepathy/AccountManager'
 
 CONN_INTERFACE_ACTIVITY_PROPERTIES = 'org.laptop.Telepathy.ActivityProperties'
 
@@ -145,26 +138,26 @@ class PresenceService(GObject.GObject):
                 The object path of the Telepathy connection
             `handle` : int or long
                 The handle of a Telepathy contact on that connection,
-                of type HANDLE_TYPE_CONTACT. This may not be a
+                of type HandleType.CONTACT. This may not be a
                 channel-specific handle.
         :Returns: the Buddy object, or None if the buddy is not found
         """
 
         bus = dbus.Bus()
-        obj = bus.get_object(ACCOUNT_MANAGER_SERVICE, ACCOUNT_MANAGER_PATH)
-        account_manager = dbus.Interface(obj, ACCOUNT_MANAGER)
-        account_paths = account_manager.Get(ACCOUNT_MANAGER, 'ValidAccounts',
+        obj = bus.get_object(TelepathyGLib.ACCOUNT_MANAGER_BUS_NAME, TelepathyGLib.ACCOUNT_MANAGER_OBJECT_PATH)
+        account_manager = dbus.Interface(obj, TelepathyGLib.IFACE_ACCOUNT_MANAGER)
+        account_paths = account_manager.Get(TelepathyGLib.IFACE_ACCOUNT_MANAGER, 'ValidAccounts',
                                             dbus_interface=PROPERTIES_IFACE)
         for account_path in account_paths:
-            obj = bus.get_object(ACCOUNT_MANAGER_SERVICE, account_path)
-            connection_path = obj.Get(ACCOUNT, 'Connection')
+            obj = bus.get_object(TelepathyGLib.ACCOUNT_MANAGER_BUS_NAME, account_path)
+            connection_path = obj.Get(TelepathyGLib.IFACE_ACCOUNT, 'Connection')
             if connection_path == tp_conn_path:
                 connection_name = connection_path.replace('/', '.')[1:]
                 connection = bus.get_object(connection_name, connection_path)
                 contact_ids = connection.InspectHandles(
-                    HANDLE_TYPE_CONTACT,
+                    TelepathyGLib.HandleType.CONTACT,
                     [handle],
-                    dbus_interface=CONNECTION)
+                    dbus_interface=TelepathyGLib.IFACE_CONNECTION)
                 return self.get_buddy(account_path, contact_ids[0])
 
         raise ValueError('Unknown buddy in connection %s with handle %d' %
@@ -227,8 +220,8 @@ class PresenceService(GObject.GObject):
                               self.__share_activity_error_cb)
 
     def get_preferred_connection(self):
-        """Gets the preferred telepathy connection object that an activity
-        should use when talking directly to telepathy
+        """Gets the preferred TelepathyGLib connection object that an activity
+        should use when talking directly to TelepathyGLib
 
         returns the bus name and the object path of the Telepathy connection
         """

--- a/src/sugar3/presence/sugartubeconn.py
+++ b/src/sugar3/presence/sugartubeconn.py
@@ -19,8 +19,7 @@
 STABLE.
 """
 
-from telepathy.constants import (
-    CHANNEL_GROUP_FLAG_CHANNEL_SPECIFIC_HANDLES)
+from gi.repository import TelepathyGLib
 
 from sugar3.presence.tubeconn import TubeConnection
 from sugar3.presence import presenceservice
@@ -39,7 +38,7 @@ class SugarTubeConnection(TubeConnection):
         return self
 
     def get_buddy(self, cs_handle):
-        """Retrieve a Buddy object given a telepathy handle.
+        """Retrieve a Buddy object given a TelepathyGLib handle.
 
         cs_handle: A channel-specific CONTACT type handle.
         returns: sugar3.presence Buddy object or None
@@ -49,7 +48,7 @@ class SugarTubeConnection(TubeConnection):
             # It's me, just get my global handle
             handle = self._conn.GetSelfHandle()
         elif self._group_iface.GetGroupFlags() & \
-                CHANNEL_GROUP_FLAG_CHANNEL_SPECIFIC_HANDLES:
+                TelepathyGLib.ChannelGroupFlags.CHANNEL_SPECIFIC_HANDLES:
             # The group (channel) has channel specific handles
             handle = self._group_iface.GetHandleOwners([cs_handle])[0]
         else:


### PR DESCRIPTION
### Explanation
Continues with #389 but it's still **in progress**. This PR ports to TelepathyGLib.

### Reason
The telepathy library does not have its bindings for Python 3, and porting Telepathy to its PyGObject binding is a pre requisite for the Port to Python 3 Project. 

*I tested it to see that activities continue working, and they do. However I encourage you to not trust me and test it by yourselves.*