### PR TITLE
Clean up activity environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ ltmain.sh
 missing
 compile
 /doc
+*.tar.xz


### PR DESCRIPTION
Ensure environment variables needed by Python activities are available in each of the three supported scenarios;

- started from Sugar,
- started from Terminal inside Sugar,
- started by other desktop environments.

Variables always available are;
```
SUGAR_ACTIVITY_ROOT
SUGAR_BUNDLE_ID
SUGAR_BUNDLE_NAME
SUGAR_BUNDLE_PATH
SUGAR_BUNDLE_VERSION
```
Variables also available when started from Sugar are;
```
SUGAR_ACTIVITIES_HIDDEN
SUGAR_APISOCKET_KEY
SUGAR_APISOCKET_PORT
SUGAR_GROUP_LABELS
SUGAR_HOME
SUGAR_MIME_DEFAULTS
SUGAR_PROFILE
SUGAR_SCALING
SUGAR_VERSION
```
Variables also available when started from Terminal are;
```
SUGAR_TERMINAL_VERSION
```
Other changes;

- use os.makedirs in place of distutils.dir_util.mkpath,
- avoid redundant setting of SUGAR_BUNDLE_PATH,
- do not set SUGAR_BUNDLE_ID unnecessarily,
- add explanatory comment,

Tested on Ubuntu 18.04.

Relates to discussion on https://github.com/sugarlabs/terminal-activity/pull/34