### PR TITLE
Build for either python 2 or python 3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,8 +15,17 @@ GNOME_COMPILE_WARNINGS(maximum)
 
 AC_PATH_PROG([GLIB_GENMARSHAL], [glib-genmarshal])
 
-PYTHON=python3
-AM_PATH_PYTHON
+AC_ARG_WITH([python2],
+        AS_HELP_STRING([--with-python2], [build for Python 2 (default)]),
+        [], [with_python2=unset])
+
+AC_ARG_WITH([python3],
+        AS_HELP_STRING([--with-python3], [build for Python 3]),
+        [with_python2=no], [with_python3=unset])
+
+AS_IF([test "x$with_python2" != xno],
+      	[AM_PATH_PYTHON([2.7])],
+	[AS_IF([test "x$with_python3" = xyes], [AM_PATH_PYTHON([3])],)])
 
 PKG_CHECK_MODULES(EXT, gtk+-3.0 gdk-3.0 gdk-pixbuf-2.0 sm ice alsa
                        librsvg-2.0 xfixes xi x11)


### PR DESCRIPTION
`configure` and `autogen.sh` now accept `--with-python2` or `--with-python3` options, with the default of python 2.

aa8a5e7 introduced building for python 3, but broke build for python 2, requiring patching `configure.ac` prior to build.

Code was derived from rpmfusion-packager, found using a GitHub search of `configure.ac` files for both `python2` and `python3`, and is GPLv3.

Tested on Ubuntu 18.04.

Signed-off-by: James Cameron <quozl@laptop.org>

@Aniket21mathur, please test.