### PR TITLE
Defer Gtk.Window.iconify

### DIFF
--- a/src/sugar3/activity/activity.py
+++ b/src/sugar3/activity/activity.py
@@ -361,6 +361,8 @@ class Activity(Window, Gtk.Container):
         self.connect('realize', self.__realize_cb)
         self.connect('delete-event', self.__delete_event_cb)
 
+        self._in_main = False
+        self._iconify = False
         self._active = False
         self._active_time = None
         self._spent_time = 0
@@ -468,7 +470,16 @@ class Activity(Window, Gtk.Container):
         """
         self._stop_buttons.append(button)
 
+    def iconify(self):
+        if not self._in_main:
+            self._iconify = True  # i.e. do after Window.show()
+        else:
+            Window.iconify(self)
+
     def run_main_loop(self):
+        if self._iconify:
+            Window.iconify(self)
+        self._in_main = True
         Gtk.main()
 
     def _initialize_journal_object(self):


### PR DESCRIPTION
Defer `iconify` call to after the activity has been shown.  Remember the `iconify` call was requested, and make the call just prior to entering the main loop.

On Ubuntu 18.04 with Metacity 3.32.0 the Journal does appear over the Home View on Sugar start on a VM with two virtual CPUs, yet the previous fix in Metacity (074af8f) is present.  This is suggestive of a race condition.

Tests with a minimal GTK reproducer shows order of three specific calls is critical to success of iconify.  The ordering and results are;

* `iconify`, `maximize`, `show`; not iconified,

* `maximize`, `iconify`, `show`; not iconified,

* `iconify`, `show`, `maximize`; not iconified,

* `maximize`, `show`, `iconify`; app with focus will flicker, iconified,

* `show`, `maximize`, `iconify`; app with focus may flicker, iconified,

* `show`, `iconify`, `maximize`; app with focus may flicker, iconified,

Sugar Toolkit combined with Journal uses the "maximize, iconify, show" ordering.  Using a Hello World activity with a call to `iconify`, the new activity is not iconified.

When changed to "maximize, show, iconify" ordering, there is no flicker of the app in focus, and the new activity is iconified.