### PR TITLE
Dash in signal names

### DIFF
--- a/src/sugar3/graphics/colorbutton.py
+++ b/src/sugar3/graphics/colorbutton.py
@@ -83,8 +83,8 @@ class _ColorButton(Gtk.Button):
                              [Gtk.TargetEntry.new(
                                  'application/x-color', 0, 0)],
                              Gdk.DragAction.COPY)
-        self.connect('drag_data_received', self.__drag_data_received_cb)
-        self.connect('drag_data_get', self.__drag_data_get_cb)
+        self.connect('drag-data-received', self.__drag_data_received_cb)
+        self.connect('drag-data-get', self.__drag_data_get_cb)
 
         self._preview.fill_color = get_svg_color_string(self._color)
         self._preview.stroke_color = self._get_fg_style_color_str()

--- a/src/sugar3/graphics/iconentry.py
+++ b/src/sugar3/graphics/iconentry.py
@@ -37,7 +37,7 @@ class IconEntry(Gtk.Entry):
         self._clear_icon = None
         self._clear_shown = False
 
-        self.connect('key_press_event', self._keypress_event_cb)
+        self.connect('key-press-event', self._keypress_event_cb)
 
     def set_icon_from_name(self, position, name):
         icon_theme = Gtk.IconTheme.get_default()

--- a/src/sugar3/graphics/tray.py
+++ b/src/sugar3/graphics/tray.py
@@ -64,7 +64,7 @@ class _TrayViewport(Gtk.Viewport):
         self.add(self.traybar)
         self.traybar.show()
 
-        self.connect('size_allocate', self._size_allocate_cb)
+        self.connect('size-allocate', self._size_allocate_cb)
 
         if self.orientation == Gtk.Orientation.HORIZONTAL:
             adj = self.get_hadjustment()


### PR DESCRIPTION
GLib accepts signal names with dash or underscore and
documents the signals with a dash.

Use of signal names in Sugar was mixed, change to using
dash only.

No functional change.