### PR TITLE
Port to Python 3 - preview metadata is bytes

### DIFF
--- a/src/sugar3/graphics/objectchooser.py
+++ b/src/sugar3/graphics/objectchooser.py
@@ -79,12 +79,12 @@ def get_preview_pixbuf(preview_data, width=-1, height=-1):
     pixbuf = None
 
     if len(preview_data) > 4:
-        if preview_data[1:4] != 'PNG':
+        if preview_data[1:4] != b'PNG':
             # TODO: We are close to be able to drop this.
             import base64
             preview_data = base64.b64decode(preview_data)
 
-        png_file = six.StringIO(preview_data)
+        png_file = six.BytesIO(preview_data)
         try:
             # Load image and scale to dimensions
             surface = cairo.ImageSurface.create_from_png(png_file)


### PR DESCRIPTION
Preview metadata in 0.114 and earlier was returned by datastore client as a dbus.ByteArray.

Regression introduced by aa8a5e7 ("Port from Python 2 to six").

```log
Traceback (most recent call last):
  File "/usr/lib/python3.7/dist-packages/jarabe/journal/expandedentry.py", line 378, in _create_preview
    pixbuf = get_preview_pixbuf(metadata.get('preview', ''))
  File "/usr/lib/python3.7/dist-packages/sugar3/graphics/objectchooser.py", line 85, in get_preview_pixbuf
    preview_data = base64.b64decode(preview_data)
  File "/usr/lib/python3.7/base64.py", line 87, in b64decode
    return binascii.a2b_base64(s)
binascii.Error: Invalid base64-encoded string: number of data characters (237) cannot be 1 more than a multiple of 4
```

Related to
https://github.com/sugarlabs/sugar-datastore/issues/16

Requires
https://github.com/sugarlabs/sugar-datastore/pull/18/commits/fb1a745159521c2887d8a4141fcfde7aea212481 in https://github.com/sugarlabs/sugar-datastore/pull/18