### PR TITLE
use xml.etree.ElementTree as xml.etree.CElementTree will be deprecated

### DIFF
--- a/src/sugar3/activity/bundlebuilder.py
+++ b/src/sugar3/activity/bundlebuilder.py
@@ -42,7 +42,7 @@ import logging
 from glob import glob
 from fnmatch import fnmatch
 from six.moves.configparser import ConfigParser
-import xml.etree.cElementTree as ET
+import xml.etree.ElementTree as ET
 from six.moves.html_parser import HTMLParser
 
 from sugar3 import env


### PR DESCRIPTION
This is a fix for https://bugzilla.redhat.com/show_bug.cgi?id=1817644 

@nullr0ute @aperezbios 

@quozl kindly review.