### PR TITLE
Fixes "Logs are not line buffered" #868 issue in sugar repo

### DIFF
--- a/src/sugar3/logger.py
+++ b/src/sugar3/logger.py
@@ -171,7 +171,7 @@ def start(log_filename=None):
         try:
             log_path = os.path.join(logs_path, log_filename + '.log')
 
-            log_fd = os.open(log_path, os.O_WRONLY | os.O_CREAT)
+            log_fd = os.open(log_path, os.O_WRONLY | os.O_CREAT, buffer=1)
             os.dup2(log_fd, sys.stdout.fileno())
             os.dup2(log_fd, sys.stderr.fileno())
             os.close(log_fd)


### PR DESCRIPTION
Reason why it was working in python 2 is because this file is
added only when switched to python 3. Compare
[logger.py](https://github.com/sugarlabs/sugar-toolkit-gtk3/blob/v0.95.2/src/sugar3/logger.py)
file in sugar3 directory of v0.95.2 with
[sugar directory](https://github.com/sugarlabs/sugar-toolkit-gtk3/tree/v0.95.1/src/sugar)
of v0.95.1

Following is not address in this commit from https://github.com/sugarlabs/sugar/issues/868:
> Perhaps what we should be doing now is to configure Sugar and activities for fully buffered logs, and configure line-buffering only when Sugar is being used by a developer. i.e. set `sys.stderr.line_buffering = True` based on an environment variable. Comments?