### PR TITLE
Fix bundlebuilder not handling empty arguments

### DIFF
--- a/src/sugar3/activity/bundlebuilder.py
+++ b/src/sugar3/activity/bundlebuilder.py
@@ -629,9 +629,9 @@ def start():
     source_dir = os.path.abspath(os.path.dirname(sys.argv[0]))
     config = Config(source_dir)
 
-    try:
-        globals()['cmd_' + options.command](config, options)
-    except (KeyError, IndexError):
+    if 'cmd_' + (options.command or '') in globals():
+        globals()['cmd_' + (options.command or '')](config, options)
+    else:
         parser.print_help()
 
 


### PR DESCRIPTION
If no arguments are passed, parser.parse_args() returns
command = None

Traceback:
```
$ python2 ./setup.py
usage: ./setup.py [-h]
                  {install,check,dist_xo,dist_source,build,fix_manifest,genpot,dev}
                  ...
./setup.py: error: too few arguments

$ python3 ./setup.py
Traceback (most recent call last):
  File "./setup.py", line 5, in <module>
    bundlebuilder.start()
  File "/usr/lib/python3.7/dist-packages/sugar3/activity/bundlebuilder.py", line 637, in start
    globals()['cmd_' + options.command](config, options)
TypeError: can only concatenate str (not "NoneType") to str
```