### PR TITLE
ci: automatically deploy documentation to gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,45 @@
+
+name: Documentation
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        
+      - name: Prepare apt repositories
+        run: | 
+          sudo sed -i '/deb-src/s/^# //' /etc/apt/sources.list
+          sudo apt update
+
+      - name: Install sugar-toolkit-gtk3
+        run: |
+          sudo apt build-dep sugar-toolkit-gtk3
+          sudo apt install python-is-python3 python3-cairo python3-gi python3-gi-cairo python3-dateutil python3-decorator \
+            gir1.2-telepathyglib-0.12 gir1.2-webkit2-4.0 python3-empy gir1.2-sugarext-1.0
+          ./autogen.sh --with-python2
+          make
+          ./autogen.sh --with-python3
+          make
+          
+      - name: Install Sphinx
+        run: |
+          sudo apt-get -qqy install sphinx-common
+          
+      - name: Build docs
+        run: |
+          ./make-doc.sh
+          mkdir deploy
+          mv doc/_build/html deploy/sugar3
+          touch deploy/.nojekyll
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: deploy  # The folder the action should deploy.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,40 +2,35 @@
 name: Documentation
 on:
   push:
-    branches: [ master ]
   workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-        
-      - name: Prepare apt repositories
-        run: | 
-          sudo sed -i '/deb-src/s/^# //' /etc/apt/sources.list
-          sudo apt update
+    container:
+      image: 'archlinux:latest'
 
-      - name: Install sugar-toolkit-gtk3
+    steps:
+      - name: Install dependencies
         run: |
-          sudo apt build-dep sugar-toolkit-gtk3
-          sudo apt install python-is-python3 python3-cairo python3-gi python3-gi-cairo python3-dateutil python3-decorator \
-            gir1.2-telepathyglib-0.12 gir1.2-webkit2-4.0 python3-empy gir1.2-sugarext-1.0
-          ./autogen.sh --with-python2
-          make
-          ./autogen.sh --with-python3
-          make
-          
-      - name: Install Sphinx
+          # assume yes and do not ask for confirmation when installing deps using pacman
+          yes | pacman -Syu base-devel sudo git wget curl python-sphinx rsync --noconfirm
+
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Create builduser
         run: |
-          sudo apt-get -qqy install sphinx-common
-          
-      - name: Build docs
+          # A user is required so that the docs are not built as root
+          useradd builduser -m # Create the builduser
+          passwd -d builduser # Delete the buildusers password
+          printf 'builduser ALL=(ALL) ALL\n' | tee -a /etc/sudoers
+
+      - name: Build documentation
         run: |
-          ./make-doc.sh
-          mkdir deploy
-          mv doc/_build/html deploy/sugar3
-          touch deploy/.nojekyll
+          sudo chown builduser:builduser . -R
+          sudo -u builduser ./ci/docs.sh
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@3.7.1

--- a/ci/docs.sh
+++ b/ci/docs.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Helper script to build documentation using Sphinx
+# NOTE: Should only be run on archlinux:latest 
+
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+set -eux
+
+show-green () {
+    echo -e "${GREEN} ==> ${1} ${NC}" 
+}
+
+# build package from the AUR (arch user repository)
+if command -v makepkg &> /dev/null
+then
+    show-green "Cloning sugar-toolkit-gtk3-git from AUR"
+    mkdir .cache
+    cd .cache 
+    git clone https://aur.archlinux.org/sugar-toolkit-gtk3-git.git
+    cd sugar-toolkit-gtk3-git
+    makepkg -sif --noconfirm 
+    show-green "Installing optional dependencies"
+    yes | sudo pacman -S --needed $(cat .SRCINFO| grep 'optdepends' | grep -o '= .*:' | sed 's,= ,,g' | sed 's,:,,g') --noconfirm
+    cd ../..
+    show-green "Dependencies synced, packages built"
+
+fi
+
+
+# make source
+show-green "Compiling"
+./autogen.sh --with-python3
+make
+
+# make documentation
+show-green "Building documentation"
+./make-doc.sh
+mkdir deploy
+mv doc/_build/html deploy/sugar3
+touch deploy/.nojekyll
+# create an index.html so that users dont become confused
+show-green "Writing index.html"
+echo "<h1>Page Moved</h1>" > index.html
+echo "<p>We have moved this page to <a href=\"https://github.com/sugarlabs/sugar-docs/blob/master/README.md\">GitHub</a>.</p>" >> index.html
+echo "<p>How did you get here? Please <a href=\"https://github.com/sugarlabs/sugar-docs/issues\">report</a> any lingering links.</p>" >> index.html
+
+show-green "Done"


### PR DESCRIPTION
```
ci: install sphinx
ci: deploy to sugar3 subdirectory
ci: add deploy/.nojekyll
ci: first make sugar-toolkit-gtk3 before docs
ci: enable deb-src repositories
ci: add gir1.2-sugarext-1.0 and remove sugar build
```

## Procedure
* Merge this pull request after reviewing the difference between https://developer.sugarlabs.org/sugar3 and https://dev.sl.srevinsaju.me/sugar3
* Ping me on IRC :smile:

