### PR TITLE
ci: add sphinxcontrib.napoleon for parsing sugar docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,8 @@ name: Documentation
 on:
   push:
     branches: [master]
+  pull_request:
+    branches: [master]
   workflow_dispatch:
 
 jobs:
@@ -15,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           # assume yes and do not ask for confirmation when installing deps using pacman
-          yes | pacman -Syu base-devel sudo git wget curl python-sphinx rsync --noconfirm
+          yes | pacman -Syu base-devel sudo git wget curl python-sphinx rsync python-pip --noconfirm
 
       - uses: actions/checkout@v2
         with:
@@ -35,6 +37,9 @@ jobs:
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@3.7.1
+        # build the documentation, but only deploy them when the PR
+        # gets merged
+        if: github.ref == 'refs/heads/master'
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.

--- a/ci/docs.sh
+++ b/ci/docs.sh
@@ -15,6 +15,11 @@ show-green () {
 # build package from the AUR (arch user repository)
 if command -v makepkg &> /dev/null
 then
+    # sphinx extensions 
+    
+    # sphinxcontrib.napolean
+    pip install sphinxcontrib-napoleon --user
+
     show-green "Cloning sugar-toolkit-gtk3-git from AUR"
     mkdir .cache
     cd .cache 


### PR DESCRIPTION
sphinxcontrib.napolean is not provided any more by the default
sphink package, so we will need to manually add them