### PR TITLE
Include <gdk/gdkx.h> for a declaration of gdk_x11_set_sm_client_id

### DIFF
--- a/src/sugar3/eggsmclient-xsmp.c
+++ b/src/sugar3/eggsmclient-xsmp.c
@@ -39,6 +39,7 @@
 #include <X11/SM/SMlib.h>
 
 #include <gdk/gdk.h>
+#include <gdk/gdkx.h>
 
 static const char *state_names[] = {
   "start",


### PR DESCRIPTION
This avoids an implicit function declaration and build failures with future compilers.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
