### PR TITLE
Fix issue with Buddy.props.key being bytes

### DIFF
--- a/src/sugar3/presence/buddy.py
+++ b/src/sugar3/presence/buddy.py
@@ -226,7 +226,7 @@ class Buddy(BaseBuddy):
 
     def _update_properties(self, properties):
         if 'key' in properties:
-            self.props.key = properties['key']
+            self.props.key = properties['key'].decode()
         if 'color' in properties:
             self.props.color = properties['color']
         if 'current-activity' in properties:


### PR DESCRIPTION
Fixes #443 

Buddy.props.key is supposed to be a str, but is stored as a dbus.ByteArray before being sent to dbus, decoding it after the call to GetProperties fixes the issue of it being bytes.

Activities like maze that use Buddy.props.key needed to encode the received key before comparison worked.

@quozl kindly review.

Tested without `key = str(key.encode())` in maze activity and collaboration works as expected.
