### PR TITLE
Fix deprecated readfp method of configparser

### DIFF
--- a/src/sugar3/bundle/activitybundle.py
+++ b/src/sugar3/bundle/activitybundle.py
@@ -133,7 +133,7 @@ class ActivityBundle(Bundle):
         if six.PY2:
             cp.readfp(info_file)
         else:
-            cp.read_string(info_file.read().decode())
+            cp.read_file(info_file)
 
         section = 'Activity'
 
@@ -258,7 +258,7 @@ class ActivityBundle(Bundle):
             if six.PY2:
                 cp.readfp(linfo_file)
             else:
-                cp.read_string(linfo_file.read().decode())
+                cp.read_file(linfo_file)
         except ParsingError as e:
             logging.exception('Exception reading linfo file: %s', e)
             return

--- a/src/sugar3/bundle/contentbundle.py
+++ b/src/sugar3/bundle/contentbundle.py
@@ -68,7 +68,7 @@ class ContentBundle(Bundle):
 
     def _parse_info(self, info_file):
         cp = ConfigParser()
-        cp.readfp(info_file)
+        cp.read_file(info_file)
 
         section = 'Library'
 

--- a/src/sugar3/graphics/icon.py
+++ b/src/sugar3/graphics/icon.py
@@ -214,7 +214,7 @@ class _IconBuffer(object):
                 try:
                     with open(icon_filename) as config_file:
                         cp = ConfigParser()
-                        cp.readfp(config_file)
+                        cp.read_file(config_file)
                         attach_points_str = cp.get('Icon Data', 'AttachPoints')
                         attach_points = attach_points_str.split(',')
                         attach_x = float(attach_points[0].strip()) / 1000


### PR DESCRIPTION
## Content: 
- This Pull Request addresses the deprecation of the readfp method in the configparser module. The readfp method has been replaced with the read_file method to ensure compatibility with newer versions of Python.
- Fixes #477
 
## Changes:
Replaced readfp with read_file in all instances.

 