### PR TITLE
Add GType registration for SugarEventController and SugarSwipeController states

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
           sudo apt install -y build-essential sudo git wget curl python3-sphinx rsync
 
           # install sugar-toolkit-gtk3 dependencies
-          sudo apt install -y python-all-dev python3-all-dev libgtk-3-dev
+          sudo apt install -y python-dev-is-python3 python3-dev libgtk-3-dev
           sudo apt install -y libgdk-pixbuf2.0-dev libsm-dev libice-dev librsvg2-dev
           sudo apt install -y libxfixes-dev libxi-dev libx11-dev gettext intltool
           sudo apt install -y libxml-parser-perl x11proto-core-dev libasound2-dev

--- a/src/sugar3/event-controller/sugar-event-controller.c
+++ b/src/sugar3/event-controller/sugar-event-controller.c
@@ -21,6 +21,7 @@
 
 #include "sugar-event-controller.h"
 #include "sugar-enum-types.h"
+#include <glib-object.h>
 
 typedef struct _SugarControllerItem SugarControllerItem;
 typedef struct _SugarControllerWidgetData SugarControllerWidgetData;
@@ -51,6 +52,24 @@ struct _SugarControllerWidgetData
   GtkWidget *widget;
   SugarEventController *current_exclusive;
 };
+
+GType sugar_event_controller_state_get_type(void) {
+    static GType etype = 0;
+    static const GEnumValue values[] = {
+        {SUGAR_EVENT_CONTROLLER_STATE_NONE, "SUGAR_EVENT_CONTROLLER_STATE_NONE", "none"},
+        {SUGAR_EVENT_CONTROLLER_STATE_COLLECTING, "SUGAR_EVENT_CONTROLLER_STATE_COLLECTING", "collecting"},
+        {SUGAR_EVENT_CONTROLLER_STATE_RECOGNIZED, "SUGAR_EVENT_CONTROLLER_STATE_RECOGNIZED", "recognized"},
+        {SUGAR_EVENT_CONTROLLER_STATE_NOT_RECOGNIZED, "SUGAR_EVENT_CONTROLLER_STATE_NOT_RECOGNIZED", "not-recognized"},
+        {0, NULL, NULL}
+    };
+
+    if (etype == 0) {
+        etype = g_enum_register_static("SugarEventControllerState", values);
+    }
+
+    return etype;
+}
+
 
 G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (SugarEventController,
                                      sugar_event_controller,

--- a/src/sugar3/event-controller/sugar-event-controller.h
+++ b/src/sugar3/event-controller/sugar-event-controller.h
@@ -36,6 +36,7 @@ G_BEGIN_DECLS
 #define SUGAR_IS_EVENT_CONTROLLER(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), SUGAR_TYPE_EVENT_CONTROLLER))
 #define SUGAR_IS_EVENT_CONTROLLER_CLASS(k)  (G_TYPE_CHECK_CLASS_TYPE ((k), SUGAR_TYPE_EVENT_CONTROLLER))
 #define SUGAR_EVENT_CONTROLLER_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS ((o), SUGAR_TYPE_EVENT_CONTROLLER, SugarEventControllerClass))
+#define SUGAR_TYPE_EVENT_CONTROLLER_STATE (sugar_event_controller_state_get_type())
 
 typedef struct _SugarEventController SugarEventController;
 typedef struct _SugarEventControllerClass SugarEventControllerClass;
@@ -82,6 +83,7 @@ struct _SugarEventControllerPrivate
 };
 
 GType     sugar_event_controller_get_type     (void) G_GNUC_CONST;
+GType sugar_event_controller_state_get_type(void) G_GNUC_CONST;
 gboolean  sugar_event_controller_handle_event (SugarEventController *controller,
 					       GdkEvent             *event);
 gboolean  sugar_event_controller_attach       (SugarEventController      *controller,

--- a/src/sugar3/event-controller/sugar-swipe-controller.c
+++ b/src/sugar3/event-controller/sugar-swipe-controller.c
@@ -21,6 +21,8 @@
 
 #include "sugar-swipe-controller.h"
 #include "sugar-enum-types.h"
+#include <glib-object.h>
+
 
 #define CHECK_TIME 100
 #define SWIPE_PX_THRESHOLD 80
@@ -45,6 +47,40 @@ struct _SugarEventData
 };
 
 static guint signals[LAST_SIGNAL] = { 0 };
+
+GType sugar_swipe_direction_get_type(void) {
+    static GType etype = 0;
+    static const GEnumValue values[] = {
+        {SUGAR_SWIPE_DIRECTION_LEFT, "SUGAR_SWIPE_DIRECTION_LEFT", "left"},
+        {SUGAR_SWIPE_DIRECTION_RIGHT, "SUGAR_SWIPE_DIRECTION_RIGHT", "right"},
+        {SUGAR_SWIPE_DIRECTION_UP, "SUGAR_SWIPE_DIRECTION_UP", "up"},
+        {SUGAR_SWIPE_DIRECTION_DOWN, "SUGAR_SWIPE_DIRECTION_DOWN", "down"},
+        {0, NULL, NULL}
+    };
+
+    if (etype == 0) {
+        etype = g_enum_register_static("SugarSwipeDirection", values);
+    }
+
+    return etype;
+}
+
+GType sugar_swipe_direction_flags_get_type(void) {
+    static GType etype = 0;
+    static const GFlagsValue values[] = {
+        {SUGAR_SWIPE_DIRECTION_FLAG_LEFT, "SUGAR_SWIPE_DIRECTION_FLAG_LEFT", "left"},
+        {SUGAR_SWIPE_DIRECTION_FLAG_RIGHT, "SUGAR_SWIPE_DIRECTION_FLAG_RIGHT", "right"},
+        {SUGAR_SWIPE_DIRECTION_FLAG_UP, "SUGAR_SWIPE_DIRECTION_FLAG_UP", "up"},
+        {SUGAR_SWIPE_DIRECTION_FLAG_DOWN, "SUGAR_SWIPE_DIRECTION_FLAG_DOWN", "down"},
+        {0, NULL, NULL}
+    };
+
+    if (etype == 0) {
+        etype = g_flags_register_static("SugarSwipeDirectionFlags", values);
+    }
+
+    return etype;
+}
 
 G_DEFINE_TYPE_WITH_PRIVATE (SugarSwipeController,
                             sugar_swipe_controller,

--- a/src/sugar3/event-controller/sugar-swipe-controller.h
+++ b/src/sugar3/event-controller/sugar-swipe-controller.h
@@ -23,79 +23,66 @@
 #error "Only <sugar/event-controller/sugar-event-controllers.h> can be included directly."
 #endif
 
-#ifndef __SUGAR_EVENT_CONTROLLER_H__
-#define __SUGAR_EVENT_CONTROLLER_H__
+#ifndef __SUGAR_SWIPE_CONTROLLER_H__
+#define __SUGAR_SWIPE_CONTROLLER_H__
 
+#include "sugar-event-controller.h"
 #include <gtk/gtk.h>
 
 G_BEGIN_DECLS
 
-#define SUGAR_TYPE_EVENT_CONTROLLER         (sugar_event_controller_get_type ())
-#define SUGAR_EVENT_CONTROLLER(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), SUGAR_TYPE_EVENT_CONTROLLER, SugarEventController))
-#define SUGAR_EVENT_CONTROLLER_CLASS(k)     (G_TYPE_CHECK_CLASS_CAST ((k), SUGAR_TYPE_EVENT_CONTROLLER, SugarEventControllerClass))
-#define SUGAR_IS_EVENT_CONTROLLER(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), SUGAR_TYPE_EVENT_CONTROLLER))
-#define SUGAR_IS_EVENT_CONTROLLER_CLASS(k)  (G_TYPE_CHECK_CLASS_TYPE ((k), SUGAR_TYPE_EVENT_CONTROLLER))
-#define SUGAR_EVENT_CONTROLLER_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS ((o), SUGAR_TYPE_EVENT_CONTROLLER, SugarEventControllerClass))
-#define SUGAR_TYPE_EVENT_CONTROLLER_STATE (sugar_event_controller_state_get_type())
+#define SUGAR_TYPE_SWIPE_CONTROLLER         (sugar_swipe_controller_get_type ())
+#define SUGAR_SWIPE_CONTROLLER(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), SUGAR_TYPE_SWIPE_CONTROLLER, SugarSwipeController))
+#define SUGAR_SWIPE_CONTROLLER_CLASS(k)     (G_TYPE_CHECK_CLASS_CAST ((k), SUGAR_TYPE_SWIPE_CONTROLLER, SugarSwipeControllerClass))
+#define SUGAR_IS_SWIPE_CONTROLLER(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), SUGAR_TYPE_SWIPE_CONTROLLER))
+#define SUGAR_IS_SWIPE_CONTROLLER_CLASS(k)  (G_TYPE_CHECK_CLASS_TYPE ((k), SUGAR_TYPE_SWIPE_CONTROLLER))
+#define SUGAR_SWIPE_CONTROLLER_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS ((o), SUGAR_TYPE_SWIPE_CONTROLLER, SugarSwipeControllerClass))
 
-typedef struct _SugarEventController SugarEventController;
-typedef struct _SugarEventControllerClass SugarEventControllerClass;
-typedef struct _SugarEventControllerPrivate SugarEventControllerPrivate;
-
-typedef enum {
-  SUGAR_EVENT_CONTROLLER_STATE_NONE,
-  SUGAR_EVENT_CONTROLLER_STATE_COLLECTING,
-  SUGAR_EVENT_CONTROLLER_STATE_RECOGNIZED,
-  SUGAR_EVENT_CONTROLLER_STATE_NOT_RECOGNIZED
-} SugarEventControllerState;
+typedef struct _SugarSwipeController SugarSwipeController;
+typedef struct _SugarSwipeControllerClass SugarSwipeControllerClass;
+typedef struct _SugarSwipeControllerPrivate SugarSwipeControllerPrivate;
 
 typedef enum {
-  SUGAR_EVENT_CONTROLLER_FLAG_NONE = 0,
-  SUGAR_EVENT_CONTROLLER_FLAG_EXCLUSIVE = 1 << 0
-} SugarEventControllerFlags;
+  SUGAR_SWIPE_DIRECTION_LEFT,
+  SUGAR_SWIPE_DIRECTION_RIGHT,
+  SUGAR_SWIPE_DIRECTION_UP,
+  SUGAR_SWIPE_DIRECTION_DOWN
+} SugarSwipeDirection;
 
-struct _SugarEventController
+typedef enum {
+  SUGAR_SWIPE_DIRECTION_FLAG_LEFT  = 1 << SUGAR_SWIPE_DIRECTION_LEFT,
+  SUGAR_SWIPE_DIRECTION_FLAG_RIGHT = 1 << SUGAR_SWIPE_DIRECTION_RIGHT,
+  SUGAR_SWIPE_DIRECTION_FLAG_UP    = 1 << SUGAR_SWIPE_DIRECTION_UP,
+  SUGAR_SWIPE_DIRECTION_FLAG_DOWN  = 1 << SUGAR_SWIPE_DIRECTION_DOWN,
+} SugarSwipeDirectionFlags;
+
+struct _SugarSwipeController
 {
-  GObject parent_instance;
-
-  SugarEventControllerPrivate *priv;
+  SugarEventController parent_instance;
+  SugarSwipeControllerPrivate *priv;
 };
 
-struct _SugarEventControllerClass
+struct _SugarSwipeControllerClass
 {
-  GObjectClass parent_class;
+  SugarEventControllerClass parent_class;
 
-  /* Signals */
-  void                      (* began)        (SugarEventController *controller);
-  void                      (* updated)      (SugarEventController *controller);
-  void                      (* ended)        (SugarEventController *controller);
-
-  /* vmethods */
-  gboolean                  (* handle_event) (SugarEventController *controller,
-                                              GdkEvent             *event);
-  SugarEventControllerState (* get_state)    (SugarEventController *controller);
-  void                      (* reset)        (SugarEventController *controller);
+  void (* swipe_ended) (SugarSwipeController *controller,
+                        SugarSwipeDirection   direction);
 };
 
-struct _SugarEventControllerPrivate
+struct _SugarSwipeControllerPrivate
 {
-  GtkWidget *widget;
+  GdkDevice *device;
+  GdkEventSequence *sequence;
+  GArray *event_data;
+  guint swiping : 1;
+  guint swiped : 1;
+  guint directions : 4;
 };
 
-GType     sugar_event_controller_get_type     (void) G_GNUC_CONST;
-GType sugar_event_controller_state_get_type(void) G_GNUC_CONST;
-gboolean  sugar_event_controller_handle_event (SugarEventController *controller,
-					       GdkEvent             *event);
-gboolean  sugar_event_controller_attach       (SugarEventController      *controller,
-					       GtkWidget                 *widget,
-                                               SugarEventControllerFlags  flags);
-gboolean  sugar_event_controller_detach       (SugarEventController      *controller,
-					       GtkWidget                 *widget);
-gboolean  sugar_event_controller_reset        (SugarEventController *controller);
-
-SugarEventControllerState
-          sugar_event_controller_get_state    (SugarEventController *controller);
+GType                  sugar_swipe_controller_get_type (void) G_GNUC_CONST;
+SugarEventController * sugar_swipe_controller_new      (SugarSwipeDirectionFlags directions);
 
 G_END_DECLS
 
-#endif /* __SUGAR_EVENT_CONTROLLER_H__ */
+#endif /* __SUGAR_SWIPE_CONTROLLER_H__ */

--- a/src/sugar3/event-controller/sugar-swipe-controller.h
+++ b/src/sugar3/event-controller/sugar-swipe-controller.h
@@ -23,66 +23,79 @@
 #error "Only <sugar/event-controller/sugar-event-controllers.h> can be included directly."
 #endif
 
-#ifndef __SUGAR_SWIPE_CONTROLLER_H__
-#define __SUGAR_SWIPE_CONTROLLER_H__
+#ifndef __SUGAR_EVENT_CONTROLLER_H__
+#define __SUGAR_EVENT_CONTROLLER_H__
 
-#include "sugar-event-controller.h"
 #include <gtk/gtk.h>
 
 G_BEGIN_DECLS
 
-#define SUGAR_TYPE_SWIPE_CONTROLLER         (sugar_swipe_controller_get_type ())
-#define SUGAR_SWIPE_CONTROLLER(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), SUGAR_TYPE_SWIPE_CONTROLLER, SugarSwipeController))
-#define SUGAR_SWIPE_CONTROLLER_CLASS(k)     (G_TYPE_CHECK_CLASS_CAST ((k), SUGAR_TYPE_SWIPE_CONTROLLER, SugarSwipeControllerClass))
-#define SUGAR_IS_SWIPE_CONTROLLER(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), SUGAR_TYPE_SWIPE_CONTROLLER))
-#define SUGAR_IS_SWIPE_CONTROLLER_CLASS(k)  (G_TYPE_CHECK_CLASS_TYPE ((k), SUGAR_TYPE_SWIPE_CONTROLLER))
-#define SUGAR_SWIPE_CONTROLLER_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS ((o), SUGAR_TYPE_SWIPE_CONTROLLER, SugarSwipeControllerClass))
+#define SUGAR_TYPE_EVENT_CONTROLLER         (sugar_event_controller_get_type ())
+#define SUGAR_EVENT_CONTROLLER(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), SUGAR_TYPE_EVENT_CONTROLLER, SugarEventController))
+#define SUGAR_EVENT_CONTROLLER_CLASS(k)     (G_TYPE_CHECK_CLASS_CAST ((k), SUGAR_TYPE_EVENT_CONTROLLER, SugarEventControllerClass))
+#define SUGAR_IS_EVENT_CONTROLLER(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), SUGAR_TYPE_EVENT_CONTROLLER))
+#define SUGAR_IS_EVENT_CONTROLLER_CLASS(k)  (G_TYPE_CHECK_CLASS_TYPE ((k), SUGAR_TYPE_EVENT_CONTROLLER))
+#define SUGAR_EVENT_CONTROLLER_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS ((o), SUGAR_TYPE_EVENT_CONTROLLER, SugarEventControllerClass))
+#define SUGAR_TYPE_EVENT_CONTROLLER_STATE (sugar_event_controller_state_get_type())
 
-typedef struct _SugarSwipeController SugarSwipeController;
-typedef struct _SugarSwipeControllerClass SugarSwipeControllerClass;
-typedef struct _SugarSwipeControllerPrivate SugarSwipeControllerPrivate;
-
-typedef enum {
-  SUGAR_SWIPE_DIRECTION_LEFT,
-  SUGAR_SWIPE_DIRECTION_RIGHT,
-  SUGAR_SWIPE_DIRECTION_UP,
-  SUGAR_SWIPE_DIRECTION_DOWN
-} SugarSwipeDirection;
+typedef struct _SugarEventController SugarEventController;
+typedef struct _SugarEventControllerClass SugarEventControllerClass;
+typedef struct _SugarEventControllerPrivate SugarEventControllerPrivate;
 
 typedef enum {
-  SUGAR_SWIPE_DIRECTION_FLAG_LEFT  = 1 << SUGAR_SWIPE_DIRECTION_LEFT,
-  SUGAR_SWIPE_DIRECTION_FLAG_RIGHT = 1 << SUGAR_SWIPE_DIRECTION_RIGHT,
-  SUGAR_SWIPE_DIRECTION_FLAG_UP    = 1 << SUGAR_SWIPE_DIRECTION_UP,
-  SUGAR_SWIPE_DIRECTION_FLAG_DOWN  = 1 << SUGAR_SWIPE_DIRECTION_DOWN,
-} SugarSwipeDirectionFlags;
+  SUGAR_EVENT_CONTROLLER_STATE_NONE,
+  SUGAR_EVENT_CONTROLLER_STATE_COLLECTING,
+  SUGAR_EVENT_CONTROLLER_STATE_RECOGNIZED,
+  SUGAR_EVENT_CONTROLLER_STATE_NOT_RECOGNIZED
+} SugarEventControllerState;
 
-struct _SugarSwipeController
+typedef enum {
+  SUGAR_EVENT_CONTROLLER_FLAG_NONE = 0,
+  SUGAR_EVENT_CONTROLLER_FLAG_EXCLUSIVE = 1 << 0
+} SugarEventControllerFlags;
+
+struct _SugarEventController
 {
-  SugarEventController parent_instance;
-  SugarSwipeControllerPrivate *priv;
+  GObject parent_instance;
+
+  SugarEventControllerPrivate *priv;
 };
 
-struct _SugarSwipeControllerClass
+struct _SugarEventControllerClass
 {
-  SugarEventControllerClass parent_class;
+  GObjectClass parent_class;
 
-  void (* swipe_ended) (SugarSwipeController *controller,
-                        SugarSwipeDirection   direction);
+  /* Signals */
+  void                      (* began)        (SugarEventController *controller);
+  void                      (* updated)      (SugarEventController *controller);
+  void                      (* ended)        (SugarEventController *controller);
+
+  /* vmethods */
+  gboolean                  (* handle_event) (SugarEventController *controller,
+                                              GdkEvent             *event);
+  SugarEventControllerState (* get_state)    (SugarEventController *controller);
+  void                      (* reset)        (SugarEventController *controller);
 };
 
-struct _SugarSwipeControllerPrivate
+struct _SugarEventControllerPrivate
 {
-  GdkDevice *device;
-  GdkEventSequence *sequence;
-  GArray *event_data;
-  guint swiping : 1;
-  guint swiped : 1;
-  guint directions : 4;
+  GtkWidget *widget;
 };
 
-GType                  sugar_swipe_controller_get_type (void) G_GNUC_CONST;
-SugarEventController * sugar_swipe_controller_new      (SugarSwipeDirectionFlags directions);
+GType     sugar_event_controller_get_type     (void) G_GNUC_CONST;
+GType sugar_event_controller_state_get_type(void) G_GNUC_CONST;
+gboolean  sugar_event_controller_handle_event (SugarEventController *controller,
+					       GdkEvent             *event);
+gboolean  sugar_event_controller_attach       (SugarEventController      *controller,
+					       GtkWidget                 *widget,
+                                               SugarEventControllerFlags  flags);
+gboolean  sugar_event_controller_detach       (SugarEventController      *controller,
+					       GtkWidget                 *widget);
+gboolean  sugar_event_controller_reset        (SugarEventController *controller);
+
+SugarEventControllerState
+          sugar_event_controller_get_state    (SugarEventController *controller);
 
 G_END_DECLS
 
-#endif /* __SUGAR_SWIPE_CONTROLLER_H__ */
+#endif /* __SUGAR_EVENT_CONTROLLER_H__ */


### PR DESCRIPTION
## Content:
- This Pull Request adds GType registration for the SugarEventController and SugarSwipeController states. This ensures that the enums are properly registered with the GObject type system, resolving the undeclared identifier errors.

## Changes:

- Added sugar_event_controller_state_get_type function to register SugarEventControllerState enum.
- Added sugar_swipe_direction_get_type and sugar_swipe_direction_flags_get_type functions to register SugarSwipeDirection and SugarSwipeDirectionFlags enums.
- Updated sugar-key-grabber.c to include the generated sugar-marshal.h and replaced deprecated functions.

## Fixes:
- Make erros that occured. 