### PR TITLE
Improve README with detailed setup and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,135 @@
-Sugar Toolkit
-=============
+# Sugar Toolkit GTK3
 
-Sugar Toolkit provides services and a set of GTK+ widgets to build
-activities and other Sugar components on Linux based computers.
+Sugar Toolkit provides services and a set of GTK+ widgets to build activities and other Sugar components on Linux-based computers. This toolkit is designed to work seamlessly with the Sugar Learning Environment, enabling developers to create educational applications with intuitive, child-friendly interfaces.
 
-This is the GTK+ 3 binding of the Sugar Toolkit.
+---
 
-https://www.sugarlabs.org/
+## Features
+- **Pre-built GTK+ Widgets**: Simplify UI design for activities.
+- **Integration with Sugar Environment**: Access system services, datastore, and collaboration tools.
+- **Lightweight and Modular**: Build standalone activities or integrate into the Sugar desktop.
 
-https://wiki.sugarlabs.org/
+For more information, visit:
+- [Sugar Labs Official Website](https://www.sugarlabs.org/)
+- [Sugar Labs Wiki](https://wiki.sugarlabs.org/)
 
-Installing on Debian or Ubuntu
-------------------------------
+---
 
-Automatically done when you install [Sugar
-desktop](https://github.com/sugarlabs/sugar).
+## Installation
 
-To install Sugar Toolkit alone without Sugar desktop,
+### Debian/Ubuntu
+Sugar Toolkit GTK3 is automatically installed with [Sugar desktop](https://github.com/sugarlabs/sugar).
+To install Sugar Toolkit alone without Sugar desktop:
 
-```
+```bash
 sudo apt install python3-sugar3
 ```
 
-Installing on Fedora
---------------------
+### Fedora
+Similar to Debian/Ubuntu, it is included with the [Sugar desktop](https://github.com/sugarlabs/sugar).
+To install Sugar Toolkit alone without Sugar desktop:
 
-Automatically done when you install [Sugar
-desktop](https://github.com/sugarlabs/sugar).
-
-To install Sugar Toolkit alone without Sugar desktop,
-
-```
+```bash
 sudo dnf install sugar-toolkit-gtk3
 ```
 
-Building
---------
+---
 
-Sugar Toolkit follows the [GNU Coding
-Standards](https://www.gnu.org/prep/standards/).
+## Building from Source
+Sugar Toolkit GTK3 follows the [GNU Coding Standards](https://www.gnu.org/prep/standards/).
 
-Install all dependencies, especially sugar-artwork and
-sugar-datastore.
+### Prerequisites
+Ensure the following dependencies are installed:
+- `sugar-artwork`
+- `sugar-datastore`
+- `GTK+ 3`
 
-Clone the repository, run `autogen.sh`, then `make` and `make
-install`.
+### Steps
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/sugarlabs/sugar-toolkit-gtk3.git
+   cd sugar-toolkit-gtk3
+   ```
+2. Run the configuration script:
+   ```bash
+   ./autogen.sh
+   ```
+3. Build and install:
+   ```bash
+   make
+   sudo make install
+   ```
+
+---
+
+## Usage
+
+Sugar Toolkit GTK3 is primarily used to create Sugar activities. Below is a simple example of a "Hello World" activity:
+
+### File Structure
+```
+hello-world/
+├── activity/
+│   ├── activity.info
+│   └── icon.svg
+├── hello-world.py
+└── setup.py
+```
+
+### Code Example: `hello-world.py`
+```python
+from gi.repository import Gtk
+from sugar3.activity.activity import Activity
+
+class HelloWorldActivity(Activity):
+    def __init__(self, handle):
+        Activity.__init__(self, handle)
+
+        label = Gtk.Label(label="Hello, Sugar!")
+        self.set_canvas(label)
+        self.show_all()
+```
+
+### Running the Activity
+1. Bundle the activity:
+   ```bash
+   python3 setup.py dist_xo
+   ```
+2. Copy the `.xo` file to the Sugar environment's Activities folder (usually `~/Activities`).
+3. Restart Sugar and launch your activity!
+
+---
+
+## Contributing
+
+We welcome contributions from the community! Follow these steps to get started:
+
+1. **Fork the Repository**:
+   ```bash
+   git clone https://github.com/sugarlabs/sugar-toolkit-gtk3.git
+   ```
+2. **Create a Feature Branch**:
+   ```bash
+   git checkout -b feature-name
+   ```
+3. **Make Your Changes** and **Commit**:
+   ```bash
+   git commit -m "Description of changes"
+   ```
+4. **Push Your Branch**:
+   ```bash
+   git push origin feature-name
+   ```
+5. **Submit a Pull Request**: Include a clear description of your changes and why they are beneficial.
+
+Use the above process to setup and create activities, and contribute to the Sugar Labs community.
+
+---
+
+## Community and Support
+
+If you have questions or need help, you can:
+- Join the [Sugar Labs Mailing List](https://lists.sugarlabs.org/)
+- Join the chat [Element Chat](https://app.element.io/#/room/#sugar:matrix.org)
+
+

--- a/README.md
+++ b/README.md
@@ -33,12 +33,10 @@ To install Sugar Toolkit alone without Sugar desktop:
 sudo dnf install sugar-toolkit-gtk3
 ```
 
----
-
 ## Building from Source
 Sugar Toolkit GTK3 follows the [GNU Coding Standards](https://www.gnu.org/prep/standards/).
 
-### Prerequisites
+### Note
 Ensure the following dependencies are installed:
 - `sugar-artwork`
 - `sugar-datastore`
@@ -61,45 +59,6 @@ Ensure the following dependencies are installed:
    ```
 
 ---
-
-## Usage
-
-Sugar Toolkit GTK3 is primarily used to create Sugar activities. Below is a simple example of a "Hello World" activity:
-
-### File Structure
-```
-hello-world/
-├── activity/
-│   ├── activity.info
-│   └── icon.svg
-├── hello-world.py
-└── setup.py
-```
-
-### Code Example: `hello-world.py`
-```python
-from gi.repository import Gtk
-from sugar3.activity.activity import Activity
-
-class HelloWorldActivity(Activity):
-    def __init__(self, handle):
-        Activity.__init__(self, handle)
-
-        label = Gtk.Label(label="Hello, Sugar!")
-        self.set_canvas(label)
-        self.show_all()
-```
-
-### Running the Activity
-1. Bundle the activity:
-   ```bash
-   python3 setup.py dist_xo
-   ```
-2. Copy the `.xo` file to the Sugar environment's Activities folder (usually `~/Activities`).
-3. Restart Sugar and launch your activity!
-
----
-
 ## Contributing
 
 We welcome contributions from the community! Follow these steps to get started:
@@ -122,14 +81,11 @@ We welcome contributions from the community! Follow these steps to get started:
    ```
 5. **Submit a Pull Request**: Include a clear description of your changes and why they are beneficial.
 
-Use the above process to setup and create activities, and contribute to the Sugar Labs community.
-
 ---
+Use the above process to setup and create activities, and contribute to the Sugar Labs community.
 
 ## Community and Support
 
 If you have questions or need help, you can:
 - Join the [Sugar Labs Mailing List](https://lists.sugarlabs.org/)
 - Join the chat [Element Chat](https://app.element.io/#/room/#sugar:matrix.org)
-
-

--- a/README.md
+++ b/README.md
@@ -54,9 +54,17 @@ Ensure the following dependencies are installed:
    ```
 3. Build and install:
    ```bash
-   make
+   sudo make clean
+   sudo make
    sudo make install
    ```
+   
+Alternatively, you can skip the `make clean` step with:
+```bash
+sudo ./autogen.sh
+sudo make
+sudo make install
+```
 
 ---
 ## Contributing


### PR DESCRIPTION
I have enhanced the README by providing detailed information on setting up and using the Sugar Toolkit GTK3. The changes aim to improve clarity and streamline the onboarding process, making it easier for developers, especially new contributors, to get started with the project. Key updates include:

Expanded the "Features" section to highlight the toolkit's key benefits.

Added clear installation instructions for both Debian/Ubuntu and Fedora.

Included is a step-by-step guide for building the toolkit from the source.

Provided a practical example of creating a "Hello World" Sugar activity, complete with file structure and code snippets.

Enhanced the "Contributing" section with a detailed workflow for submitting changes.

Updated the "Community and Support" section with helpful resources and links.


The changes were inspired by the README files of Sugarizer and Music Blocks, as I felt adding more detailed information about the Sugar Toolkit would be beneficial.

I'm open to feedback and suggestions—please let me know if you think any further improvements are needed.

