### PR TITLE
Fix ArgumentParser syntax

### DIFF
--- a/src/sugar3/activity/activityinstance.py
+++ b/src/sugar3/activity/activityinstance.py
@@ -86,7 +86,7 @@ class SingleProcess(dbus.service.Object):
 
 
 def main():
-    usage = 'usage: %prog [options] [activity dir] [python class]'
+    usage = '%(prog)s [options] [activity dir] [python class]'
     epilog = 'If you are running from a directory containing an Activity, ' \
              'the argument may be omitted.  Otherwise please provide either '\
              'a directory containing a Sugar Activity [activity dir], a '\


### PR DESCRIPTION
This fixes the following error while running `sugar-activity3 --help`:
```python
Traceback (most recent call last):
  File "/usr/bin/sugar-activity3", line 5, in <module>
    activityinstance.main()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/sugar3/activity/activityinstance.py", line 132, in main
    parser.print_help()
    ~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/argparse.py", line 2628, in print_help
    self._print_message(self.format_help(), file)
                        ~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/argparse.py", line 2611, in format_help
    return formatter.format_help()
           ~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/argparse.py", line 287, in format_help
    help = self._root_section.format_help()
  File "/usr/lib/python3.13/argparse.py", line 216, in format_help
    item_help = join([func(*args) for func, args in self.items])
                      ~~~~^^^^^^^
  File "/usr/lib/python3.13/argparse.py", line 304, in _format_usage
    usage = usage % dict(prog=self._prog)
            ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
ValueError: unsupported format character 'p' (0x70) at index 8
```