### PR TITLE
Replace deprecated ConfigParser readfp with read_file

### DIFF
--- a/src/sugar3/bundle/contentbundle.py
+++ b/src/sugar3/bundle/contentbundle.py
@@ -68,7 +68,7 @@ class ContentBundle(Bundle):
 
     def _parse_info(self, info_file):
         cp = ConfigParser()
-        cp.readfp(info_file)
+        cp.read_file(info_file)
 
         section = 'Library'
 

--- a/src/sugar3/graphics/icon.py
+++ b/src/sugar3/graphics/icon.py
@@ -214,7 +214,7 @@ class _IconBuffer(object):
                 try:
                     with open(icon_filename) as config_file:
                         cp = ConfigParser()
-                        cp.readfp(config_file)
+                        cp.read_file(config_file)
                         attach_points_str = cp.get('Icon Data', 'AttachPoints')
                         attach_points = attach_points_str.split(',')
                         attach_x = float(attach_points[0].strip()) / 1000


### PR DESCRIPTION
ConfigParser's `readfp()` has been deprecated since Python 3.2 and removed in Python 3.12.

Reference: https://docs.python.org/3/whatsnew/3.12.html#configparser