### PR TITLE
Fix GIR build dependency ordering for --shuffle=reverse

### DIFF
--- a/src/sugar3/Makefile.am
+++ b/src/sugar3/Makefile.am
@@ -124,10 +124,11 @@ SugarExt_1_0_gir_FILES = \
     sugar-wm.c \
     sugar-wm.h
 
-SugarExt_1_0_gir: libsugarext.la
 SugarExt_1_0_gir_INCLUDES = Gtk-3.0 Gdk-3.0
 SugarExt_1_0_gir_PACKAGES = gtk+-3.0 gdk-3.0
 SugarExt_1_0_gir_EXPORT_PACKAGES = SugarExt-1.0
+SugarExt_1_0_gir_SCANNERFLAGS = --warn-all
+SugarExt-1.0.gir: libsugarext.la $(top_builddir)/src/sugar3/event-controller/libsugar-eventcontroller.la $(top_builddir)/src/sugar3/event-controller/SugarGestures-1.0.gir
 
 girdir = $(datadir)/gir-1.0
 gir_DATA = SugarExt-1.0.gir

--- a/src/sugar3/event-controller/Makefile.am
+++ b/src/sugar3/event-controller/Makefile.am
@@ -58,10 +58,10 @@ SugarGestures_1_0_gir_FILES =	\
 SugarGestures_1_0_gir_CFLAGS =	\
 	-DSUGAR_TOOLKIT_COMPILATION --warn-all
 
-SugarGestures-1.0.gir: libsugar-eventcontroller.la
 SugarGestures_1_0_gir_INCLUDES = Gtk-3.0 Gdk-3.0
 SugarGestures_1_0_gir_PACKAGES = gtk+-3.0 gdk-3.0
 SugarGestures_1_0_gir_EXPORT_PACKAGES = SugarGestures-1.0
+SugarGestures-1.0.gir: libsugar-eventcontroller.la
 
 girdir = $(datadir)/gir-1.0
 gir_DATA = $(INTROSPECTION_GIRS)


### PR DESCRIPTION
### Summary

Fixes a build failure exposed when running `make --shuffle=reverse`, as discussed in #489.

### Problem

When building with reversed shuffle order, the build fails during GIR generation:
```
libtool: error: cannot find the library 'libsugarext.la'
linking of temporary binary failed
make[4]: *** [SugarExt-1.0.gir] Error 1
```

This indicates that `SugarExt-1.0.gir` relied on implicit build ordering rather than explicit dependencies.

### Solution

- Added explicit dependencies for `SugarExt-1.0.gir` on:
  - `libsugarext.la`
  - `libsugar-eventcontroller.la`
  - `SugarGestures-1.0.gir`
- Reordered related targets in `Makefile.am` to ensure correct dependency declaration

### Verification

- `make` (normal build) Successful
- `make --shuffle=reverse` Successful
- GIR generation completes successfully

Fixes #489.

