### PR TITLE
fix: Support both DSA and RSA public keys for OpenSSH 10.0+ compatibility

### DIFF
--- a/src/sugar3/profile.py
+++ b/src/sugar3/profile.py
@@ -87,12 +87,14 @@ class Profile(object):
             logging.exception('Error reading public key')
             return None
 
-        magic = 'ssh-dss '
+        # Support both DSA (ssh-dss) for existing keys and RSA (ssh-rsa) for new keys
+        # This ensures backward compatibility with existing user profiles
+        supported_key_types = ('ssh-dss ', 'ssh-rsa ')
         for line in lines:
             line = line.strip()
-            if not line.startswith(magic):
-                continue
-            return line[len(magic):]
+            for magic in supported_key_types:
+                if line.startswith(magic):
+                    return line[len(magic):]
         else:
             logging.error('Error parsing public key.')
             return None


### PR DESCRIPTION
## Summary
OpenSSH 10.0 (released 2025-04-09) removed DSA key support. This updates `_load_pubkey()` to recognize both DSA and RSA public keys, ensuring backward compatibility for existing users while supporting new installations.

Fixes the toolkit side of: sugarlabs/sugar#1004

## Problem
The existing code only recognizes `ssh-dss` (DSA) prefix:
```python
magic = 'ssh-dss '
for line in lines:
    line = line.strip()
    if not line.startswith(magic):
        continue
    return line[len(magic):]

#Solution
Support both key types:#

supported_key_types = ('ssh-dss ', 'ssh-rsa ')
for line in lines:
    line = line.strip()
    for magic in supported_key_types:
        if line.startswith(magic):
            return line[len(magic):]


    