### PR TITLE
fix: used get_target() to ensure correctness of drag and drop option

### DIFF
--- a/src/sugar3/graphics/colorbutton.py
+++ b/src/sugar3/graphics/colorbutton.py
@@ -243,7 +243,8 @@ class _ColorButton(Gtk.Button):
     def __drag_data_get_cb(self, widget, context, selection_data, info, time):
         data = struct.pack('=HHHH', self._color.red, self._color.green,
                            self._color.blue, 65535)
-        selection_data.set(selection_data.target, 16, data)
+        target=selection_data.get_target()
+        selection_data.set(target,16,data)
 
     def __drag_data_received_cb(self, widget, context, x, y, selection_data,
                                 info, time):


### PR DESCRIPTION
This PR fixes the AttributeError: 'SelectionData' object has no attribute 'target' reported in sugarlabs/paint-activity#43


The error occurs because selection_data.target is not available in GTK3. This change replaces it with selection_data.get_target(), ensuring the drag-and-drop of colors works as expected.

fixes #496 