### PR TITLE
Fix year calculation typo in util.py

### DIFF
--- a/src/sugar3/util.py
+++ b/src/sugar3/util.py
@@ -215,7 +215,7 @@ class LRU:
         return list(self.d.keys())
 
 
-units = [['%d year', '%d years', 356 * 24 * 60 * 60],
+units = [['%d year', '%d years', 365 * 24 * 60 * 60],
          ['%d month', '%d months', 30 * 24 * 60 * 60],
          ['%d week', '%d weeks', 7 * 24 * 60 * 60],
          ['%d day', '%d days', 24 * 60 * 60],


### PR DESCRIPTION
### Summary
Porting the fix from sugarlabs/sugar-toolkit-gtk4#15 as requested by @MostlyKIGuess.

### The Fix
Corrected the constant `356` to `365` in `util.py` to ensure accurate time formatting.