### PR TITLE
chore: Backport Python antipatterns and security fixes from GTK4

### DIFF
--- a/src/sugar3/bundle/bundle.py
+++ b/src/sugar3/bundle/bundle.py
@@ -25,6 +25,7 @@ import os
 import logging
 import shutil
 import zipfile
+import subprocess
 
 
 class AlreadyInstalledException(Exception):
@@ -177,8 +178,8 @@ class Bundle(object):
         # correctly by hand, but handling all the oddities of
         # Windows/UNIX mappings, extension attributes, deprecated
         # features, etc makes it impractical.
-        if os.spawnlp(os.P_WAIT, 'unzip', 'unzip', '-o', self._path,
-                      '-x', 'mimetype', '-d', install_dir):
+        if subprocess.call(['unzip', '-o', self._path, '-x', 'mimetype',
+                            '-d', install_dir]):
             # clean up install dir after failure
             shutil.rmtree(os.path.join(install_dir, self._zip_root_dir),
                           ignore_errors=True)

--- a/src/sugar3/datastore/datastore.py
+++ b/src/sugar3/datastore/datastore.py
@@ -263,8 +263,9 @@ class RawObject(object):
         # and w/o this, it wouldn't work since we have file from mounted device
         if self._file_path is None:
             data_path = os.path.join(env.get_profile_path(), 'data')
-            self._file_path = tempfile.mktemp(
+            fd, self._file_path = tempfile.mkstemp(
                 prefix='rawobject', dir=data_path)
+            os.close(fd)
             if not os.path.exists(data_path):
                 os.makedirs(data_path)
             os.symlink(self.object_id, self._file_path)

--- a/src/sugar3/util.py
+++ b/src/sugar3/util.py
@@ -139,8 +139,10 @@ class LRU:
     Copyright 2003 Josiah Carlson.
     """
 
-    def __init__(self, count, pairs=[]):
-        # pylint: disable=W0102,W0612
+    def __init__(self, count, pairs=None):
+        if pairs is None:
+            pairs = []
+        # pylint: disable=W0612
         self.count = max(count, 1)
         self.d = {}
         self.first = None


### PR DESCRIPTION
This PR backports security and code quality fixes from the GTK4 port sugarlabs/sugar-toolkit-gtk4#18 to the stable GTK3 toolkit.

### Changes
- **`src/sugar3/util.py`**: Fixed mutable default argument in `LRU.__init__` to prevent state leakage between instances.
- **`src/sugar3/bundle/bundle.py`**: Replaced deprecated and unsafe `os.spawnlp` with `subprocess.call` (using list arguments to avoid shell injection).
- **`src/sugar3/datastore/datastore.py`**: Replaced insecure `tempfile.mktemp` with `tempfile.mkstemp`, ensuring the file descriptor is properly closed to prevent race conditions.

### Verification
I created a local verification script (`verify_fixes.py`) mocking `gi` and `sugar3` dependencies to test the logic in isolation using the GTK3 codebase.

**Test Output:**
```text
Testing Bundle unzip subprocess...
PASS: os.spawnlp was NOT called
PASS: subprocess.call was called

Testing properties of RawObject tempfile...
PASS: tempfile.mktemp was NOT called
PASS: tempfile.mkstemp was called

Testing LRU mutable default...
PASS: LRU instances do not share state.