### PR TITLE
raise preview size to 720x540

### DIFF
--- a/src/sugar3/activity/activity.py
+++ b/src/sugar3/activity/activity.py
@@ -228,7 +228,7 @@ CONNECTION_HANDLE_TYPE_ROOM = TelepathyGLib.HandleType.ROOM
 
 CONN_INTERFACE_ACTIVITY_PROPERTIES = 'org.laptop.Telepathy.ActivityProperties'
 
-PREVIEW_SIZE = style.zoom(300), style.zoom(225)
+PREVIEW_SIZE = style.zoom(720), style.zoom(540)
 """
 Size of a preview image for journal object metadata.
 """


### PR DESCRIPTION
300x225 previews read blurry on any surface larger than a thumbnail; a journal entry-page redesign proposed on the sugar repo mounts them at 672px wide. 
Consumers scale whatever they get, so nothing needs a matching change; the chooser keeps its classic cell by scaling at 5/12.